### PR TITLE
feat: standalone playback-aware Bluetooth scanning with configurable timings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2026-09-06
+
+### Added
+- Standalone media playback awareness (`SpeakerPlaybackDetector`) probing Cast V2 TLS (port 8009) and local Bluetooth status (port 8443) without Home Assistant `cast` or `media_player` dependencies.
+- Playback handling modes: `throttle` (relaxed scan cadence and reduced scan timeout), `skip_ceiling` (pause scanning during music with maximum continuous skip ceiling), and `ignore`.
+- Fully configurable timings in options flow: idle duration/interval, playing duration/interval, max skip ceiling, and RSSI threshold.
+
 ## [0.1.0] - 2026-09-06
 
 ### Added

--- a/custom_components/google_home_bt_proxy/__init__.py
+++ b/custom_components/google_home_bt_proxy/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from collections.abc import Callable
 from typing import Any
 
@@ -20,19 +21,31 @@ from .const import (
     CONF_DISABLED_SPEAKERS,
     CONF_KNOWN_IRKS,
     CONF_MASTER_TOKEN,
+    CONF_MAX_PLAYING_SKIP_DURATION,
     CONF_PASSWORD,
+    CONF_PLAYBACK_MODE,
+    CONF_PLAYING_SCAN_INTERVAL,
+    CONF_PLAYING_SCAN_TIMEOUT,
     CONF_RSSI_THRESHOLD,
     CONF_SCAN_INTERVAL,
     CONF_SCAN_TIMEOUT,
     CONF_USERNAME,
+    DEFAULT_MAX_PLAYING_SKIP_DURATION,
+    DEFAULT_PLAYBACK_MODE,
+    DEFAULT_PLAYING_SCAN_INTERVAL,
+    DEFAULT_PLAYING_SCAN_TIMEOUT,
     DEFAULT_RSSI_THRESHOLD,
     DEFAULT_SCAN_INTERVAL,
     DEFAULT_SCAN_TIMEOUT,
     DOMAIN,
+    MODE_IGNORE,
+    MODE_SKIP_CEILING,
+    MODE_THROTTLE,
 )
 from .coordinator import GoogleHomeProxyCoordinator
 from .irk import IrkResolver, parse_irk_config
 from .models import SpeakerNode
+from .playback import SpeakerPlaybackDetector
 from .scanner import GoogleHomeRemoteScanner
 
 _LOGGER = logging.getLogger(__name__)
@@ -61,6 +74,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
 
     api_client = GoogleHomeApiClient(session=session)
+    playback_detector = SpeakerPlaybackDetector(api_client=api_client)
     speakers = await coordinator.async_get_speakers()
 
     disabled_speakers: list[str] = entry.options.get(CONF_DISABLED_SPEAKERS, [])
@@ -95,7 +109,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         stagger_delay = index * 1.5
         task = hass.async_create_background_task(
             _speaker_scan_loop(
-                hass, entry, coordinator, api_client, speaker, scanner, stagger_delay
+                hass,
+                entry,
+                coordinator,
+                api_client,
+                speaker,
+                scanner,
+                stagger_delay,
+                playback_detector=playback_detector,
             ),
             name=f"google_home_bt_proxy_{speaker.device_id}",
         )
@@ -104,6 +125,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data[DOMAIN][entry.entry_id] = {
         "coordinator": coordinator,
         "api_client": api_client,
+        "playback_detector": playback_detector,
         "scanners": scanners,
         "unregister_callbacks": unregister_callbacks,
         "worker_tasks": worker_tasks,
@@ -120,54 +142,113 @@ async def _speaker_scan_loop(
     speaker: SpeakerNode,
     scanner: GoogleHomeRemoteScanner,
     initial_delay: float,
+    playback_detector: SpeakerPlaybackDetector | None = None,
 ) -> None:
     """Continuous staggered polling scan loop for an individual speaker."""
+    if playback_detector is None:
+        playback_detector = SpeakerPlaybackDetector(api_client)
+
     await asyncio.sleep(initial_delay)
     _LOGGER.info("Starting Bluetooth scan worker loop for %s", speaker.name)
 
     backoff = 1.0
+    continuous_skip_start: float | None = None
 
     while True:
-        scan_timeout = entry.options.get(CONF_SCAN_TIMEOUT, DEFAULT_SCAN_TIMEOUT)
-        scan_interval = entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
+        playback_mode = entry.options.get(CONF_PLAYBACK_MODE, DEFAULT_PLAYBACK_MODE)
+        idle_scan_timeout = entry.options.get(CONF_SCAN_TIMEOUT, DEFAULT_SCAN_TIMEOUT)
+        idle_scan_interval = entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
+        playing_scan_timeout = entry.options.get(
+            CONF_PLAYING_SCAN_TIMEOUT, DEFAULT_PLAYING_SCAN_TIMEOUT
+        )
+        playing_scan_interval = entry.options.get(
+            CONF_PLAYING_SCAN_INTERVAL, DEFAULT_PLAYING_SCAN_INTERVAL
+        )
+        max_skip_duration = entry.options.get(
+            CONF_MAX_PLAYING_SKIP_DURATION, DEFAULT_MAX_PLAYING_SKIP_DURATION
+        )
         rssi_threshold = entry.options.get(CONF_RSSI_THRESHOLD, DEFAULT_RSSI_THRESHOLD)
 
-        try:
-            # 1. Trigger hardware scan
-            await api_client.start_scan(speaker, timeout=scan_timeout)
+        is_playing = False
+        if playback_mode != MODE_IGNORE:
+            try:
+                is_playing = await playback_detector.async_is_playing(speaker)
+            except Exception as err:
+                _LOGGER.debug("Error checking playback status on %s: %s", speaker.name, err)
+                is_playing = False
 
-            # 2. Await hardware scan duration
-            await asyncio.sleep(scan_timeout)
+        should_scan = True
+        active_timeout = idle_scan_timeout
+        active_interval = idle_scan_interval
 
-            # 3. Retrieve scan results
-            results = await api_client.get_scan_results(speaker)
+        now = time.monotonic()
 
-            # 4. Inject into Home Assistant Bluetooth Manager
-            scanner.process_scan_results(results, min_rssi=rssi_threshold)
-            backoff = 1.0
+        if is_playing:
+            if continuous_skip_start is None:
+                continuous_skip_start = now
 
-        except TokenExpiredError:
-            _LOGGER.warning("Auth token expired for %s, requesting refresh...", speaker.name)
-            await coordinator.async_refresh_token(speaker)
-            await asyncio.sleep(2.0)
-            continue
-        except SpeakerConnectionError as err:
-            _LOGGER.debug(
-                "Connection issue with %s: %s (backing off %0.1fs)",
-                speaker.name,
-                err,
-                backoff,
-            )
-            await asyncio.sleep(backoff)
-            backoff = min(backoff * 2.0, 60.0)
-            continue
-        except asyncio.CancelledError:
-            _LOGGER.info("Stopping Bluetooth scan worker for %s", speaker.name)
-            raise
-        except Exception:
-            _LOGGER.exception("Unexpected error in scan loop for %s", speaker.name)
+            if playback_mode == MODE_THROTTLE:
+                active_timeout = playing_scan_timeout
+                active_interval = playing_scan_interval
+                should_scan = True
+            elif playback_mode == MODE_SKIP_CEILING:
+                elapsed_skip = now - continuous_skip_start
+                if elapsed_skip >= max_skip_duration:
+                    _LOGGER.info(
+                        "Max continuous skip ceiling reached (%0.1fs >= %0.1fs) on %s; forcing refresh scan",
+                        elapsed_skip,
+                        max_skip_duration,
+                        speaker.name,
+                    )
+                    should_scan = True
+                    active_timeout = playing_scan_timeout
+                    continuous_skip_start = now
+                else:
+                    should_scan = False
+                    active_interval = idle_scan_interval
+        else:
+            continuous_skip_start = None
+            should_scan = True
+            active_timeout = idle_scan_timeout
+            active_interval = idle_scan_interval
 
-        await asyncio.sleep(scan_interval)
+        if should_scan:
+            try:
+                # 1. Trigger hardware scan
+                await api_client.start_scan(speaker, timeout=active_timeout)
+
+                # 2. Await hardware scan duration
+                await asyncio.sleep(active_timeout)
+
+                # 3. Retrieve scan results
+                results = await api_client.get_scan_results(speaker)
+
+                # 4. Inject into Home Assistant Bluetooth Manager
+                scanner.process_scan_results(results, min_rssi=rssi_threshold)
+                backoff = 1.0
+
+            except TokenExpiredError:
+                _LOGGER.warning("Auth token expired for %s, requesting refresh...", speaker.name)
+                await coordinator.async_refresh_token(speaker)
+                await asyncio.sleep(2.0)
+                continue
+            except SpeakerConnectionError as err:
+                _LOGGER.debug(
+                    "Connection issue with %s: %s (backing off %0.1fs)",
+                    speaker.name,
+                    err,
+                    backoff,
+                )
+                await asyncio.sleep(backoff)
+                backoff = min(backoff * 2.0, 60.0)
+                continue
+            except asyncio.CancelledError:
+                _LOGGER.info("Stopping Bluetooth scan worker for %s", speaker.name)
+                raise
+            except Exception:
+                _LOGGER.exception("Unexpected error in scan loop for %s", speaker.name)
+
+        await asyncio.sleep(active_interval)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/google_home_bt_proxy/__init__.py
+++ b/custom_components/google_home_bt_proxy/__init__.py
@@ -195,7 +195,8 @@ async def _speaker_scan_loop(
                 elapsed_skip = now - continuous_skip_start
                 if elapsed_skip >= max_skip_duration:
                     _LOGGER.info(
-                        "Max continuous skip ceiling reached (%0.1fs >= %0.1fs) on %s; forcing refresh scan",
+                        "Max continuous skip ceiling reached (%0.1fs >= %0.1fs) on %s; "
+                        "forcing refresh scan",
                         elapsed_skip,
                         max_skip_duration,
                         speaker.name,

--- a/custom_components/google_home_bt_proxy/api.py
+++ b/custom_components/google_home_bt_proxy/api.py
@@ -169,4 +169,3 @@ class GoogleHomeApiClient:
         except (aiohttp.ClientError, TimeoutError) as err:
             speaker.available = False
             raise SpeakerConnectionError(f"Connection failed to {speaker.name}: {err}") from err
-

--- a/custom_components/google_home_bt_proxy/api.py
+++ b/custom_components/google_home_bt_proxy/api.py
@@ -11,6 +11,7 @@ from .classification import decode_device_class, is_resolvable_private_address
 from .const import (
     ENDPOINT_BLUETOOTH_SCAN,
     ENDPOINT_BLUETOOTH_SCAN_RESULTS,
+    ENDPOINT_BLUETOOTH_STATUS,
     ENDPOINT_EUREKA_INFO,
     HEADER_CONTENT_TYPE,
     HEADER_LOCAL_AUTH,
@@ -147,3 +148,25 @@ class GoogleHomeApiClient:
         except (aiohttp.ClientError, TimeoutError) as err:
             speaker.available = False
             raise SpeakerConnectionError(f"Connection failed to {speaker.name}: {err}") from err
+
+    async def get_bluetooth_status(self, speaker: SpeakerNode) -> dict[str, Any]:
+        """Retrieve bluetooth status from the speaker."""
+        url = self._build_url(speaker.ip_address, ENDPOINT_BLUETOOTH_STATUS)
+        try:
+            async with self._session.get(
+                url,
+                headers=self._headers(speaker.auth_token),
+                timeout=self._timeout,
+                ssl=False,
+            ) as resp:
+                if resp.status == 401:
+                    raise TokenExpiredError(f"Token expired on speaker {speaker.name}")
+                if resp.status == 200:
+                    speaker.available = True
+                    data = await resp.json()
+                    return data if isinstance(data, dict) else {}
+                return {}
+        except (aiohttp.ClientError, TimeoutError) as err:
+            speaker.available = False
+            raise SpeakerConnectionError(f"Connection failed to {speaker.name}: {err}") from err
+

--- a/custom_components/google_home_bt_proxy/config_flow.py
+++ b/custom_components/google_home_bt_proxy/config_flow.py
@@ -19,16 +19,27 @@ from .const import (
     CONF_ANDROID_ID,
     CONF_KNOWN_IRKS,
     CONF_MASTER_TOKEN,
+    CONF_MAX_PLAYING_SKIP_DURATION,
     CONF_OAUTH_TOKEN,
     CONF_PASSWORD,
+    CONF_PLAYBACK_MODE,
+    CONF_PLAYING_SCAN_INTERVAL,
+    CONF_PLAYING_SCAN_TIMEOUT,
     CONF_RSSI_THRESHOLD,
     CONF_SCAN_INTERVAL,
     CONF_SCAN_TIMEOUT,
     CONF_USERNAME,
+    DEFAULT_MAX_PLAYING_SKIP_DURATION,
+    DEFAULT_PLAYBACK_MODE,
+    DEFAULT_PLAYING_SCAN_INTERVAL,
+    DEFAULT_PLAYING_SCAN_TIMEOUT,
     DEFAULT_RSSI_THRESHOLD,
     DEFAULT_SCAN_INTERVAL,
     DEFAULT_SCAN_TIMEOUT,
     DOMAIN,
+    MODE_IGNORE,
+    MODE_SKIP_CEILING,
+    MODE_THROTTLE,
     NAME,
 )
 
@@ -203,13 +214,31 @@ class GoogleHomeBtProxyOptionsFlowHandler(config_entries.OptionsFlow):
         schema = vol.Schema(
             {
                 vol.Optional(
+                    CONF_PLAYBACK_MODE,
+                    default=options.get(CONF_PLAYBACK_MODE, DEFAULT_PLAYBACK_MODE),
+                ): vol.In([MODE_THROTTLE, MODE_SKIP_CEILING, MODE_IGNORE]),
+                vol.Optional(
                     CONF_SCAN_TIMEOUT,
                     default=options.get(CONF_SCAN_TIMEOUT, DEFAULT_SCAN_TIMEOUT),
-                ): vol.All(vol.Coerce(int), vol.Range(min=3, max=15)),
+                ): vol.All(vol.Coerce(int), vol.Range(min=2, max=15)),
                 vol.Optional(
                     CONF_SCAN_INTERVAL,
                     default=options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL),
                 ): vol.All(vol.Coerce(int), vol.Range(min=5, max=60)),
+                vol.Optional(
+                    CONF_PLAYING_SCAN_TIMEOUT,
+                    default=options.get(CONF_PLAYING_SCAN_TIMEOUT, DEFAULT_PLAYING_SCAN_TIMEOUT),
+                ): vol.All(vol.Coerce(int), vol.Range(min=1, max=10)),
+                vol.Optional(
+                    CONF_PLAYING_SCAN_INTERVAL,
+                    default=options.get(CONF_PLAYING_SCAN_INTERVAL, DEFAULT_PLAYING_SCAN_INTERVAL),
+                ): vol.All(vol.Coerce(int), vol.Range(min=10, max=300)),
+                vol.Optional(
+                    CONF_MAX_PLAYING_SKIP_DURATION,
+                    default=options.get(
+                        CONF_MAX_PLAYING_SKIP_DURATION, DEFAULT_MAX_PLAYING_SKIP_DURATION
+                    ),
+                ): vol.All(vol.Coerce(int), vol.Range(min=30, max=900)),
                 vol.Optional(
                     CONF_RSSI_THRESHOLD,
                     default=options.get(CONF_RSSI_THRESHOLD, DEFAULT_RSSI_THRESHOLD),

--- a/custom_components/google_home_bt_proxy/const.py
+++ b/custom_components/google_home_bt_proxy/const.py
@@ -17,13 +17,26 @@ CONF_ANDROID_ID: Final = "android_id"
 # Options keys
 CONF_SCAN_TIMEOUT: Final = "scan_timeout"
 CONF_SCAN_INTERVAL: Final = "scan_interval"
+CONF_PLAYBACK_MODE: Final = "playback_mode"
+CONF_PLAYING_SCAN_TIMEOUT: Final = "playing_scan_timeout"
+CONF_PLAYING_SCAN_INTERVAL: Final = "playing_scan_interval"
+CONF_MAX_PLAYING_SKIP_DURATION: Final = "max_playing_skip_duration"
 CONF_RSSI_THRESHOLD: Final = "rssi_threshold"
 CONF_DISABLED_SPEAKERS: Final = "disabled_speakers"
 CONF_KNOWN_IRKS: Final = "known_irks"
 
+# Playback modes
+MODE_THROTTLE: Final = "throttle"
+MODE_SKIP_CEILING: Final = "skip_ceiling"
+MODE_IGNORE: Final = "ignore"
+
 # Defaults
 DEFAULT_SCAN_TIMEOUT: Final = 5  # seconds for active scan
 DEFAULT_SCAN_INTERVAL: Final = 10  # seconds between scans
+DEFAULT_PLAYBACK_MODE: Final = MODE_THROTTLE
+DEFAULT_PLAYING_SCAN_TIMEOUT: Final = 2  # seconds for active scan during playback
+DEFAULT_PLAYING_SCAN_INTERVAL: Final = 30  # seconds between scans during playback
+DEFAULT_MAX_PLAYING_SKIP_DURATION: Final = 120  # seconds maximum continuous skip before forced scan
 DEFAULT_RSSI_THRESHOLD: Final = -90  # dBm
 
 # API Constants

--- a/custom_components/google_home_bt_proxy/manifest.json
+++ b/custom_components/google_home_bt_proxy/manifest.json
@@ -13,5 +13,5 @@
     "pychromecast>=14.0.0"
   ],
   "dependencies": ["bluetooth", "zeroconf"],
-  "version": "0.1.0"
+  "version": "0.2.0"
 }

--- a/custom_components/google_home_bt_proxy/manifest.json
+++ b/custom_components/google_home_bt_proxy/manifest.json
@@ -9,7 +9,8 @@
   "iot_class": "local_polling",
   "requirements": [
     "glocaltokens>=0.7.6",
-    "habluetooth>=3.8.0"
+    "habluetooth>=3.8.0",
+    "pychromecast>=14.0.0"
   ],
   "dependencies": ["bluetooth", "zeroconf"],
   "version": "0.1.0"

--- a/custom_components/google_home_bt_proxy/playback.py
+++ b/custom_components/google_home_bt_proxy/playback.py
@@ -20,7 +20,7 @@ ACTIVE_PLAYER_STATES = {"PLAYING", "BUFFERING"}
 
 
 class SpeakerPlaybackDetector:
-    """Detects active media playback directly against a speaker without Home Assistant core dependencies."""
+    """Detects active media playback directly against a speaker without HA dependencies."""
 
     def __init__(self, api_client: GoogleHomeApiClient, cast_timeout: float = 3.0) -> None:
         """Initialize the playback detector."""

--- a/custom_components/google_home_bt_proxy/playback.py
+++ b/custom_components/google_home_bt_proxy/playback.py
@@ -1,0 +1,103 @@
+"""Standalone media playback detector for Google Home / Nest speakers."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+from typing import TYPE_CHECKING
+
+import pychromecast
+from pychromecast.models import CastInfo, HostServiceInfo
+
+if TYPE_CHECKING:
+    from .api import GoogleHomeApiClient
+    from .models import SpeakerNode
+
+_LOGGER = logging.getLogger(__name__)
+
+ACTIVE_PLAYER_STATES = {"PLAYING", "BUFFERING"}
+
+
+class SpeakerPlaybackDetector:
+    """Detects active media playback directly against a speaker without Home Assistant core dependencies."""
+
+    def __init__(self, api_client: GoogleHomeApiClient, cast_timeout: float = 3.0) -> None:
+        """Initialize the playback detector."""
+        self._api_client = api_client
+        self._cast_timeout = cast_timeout
+
+    async def async_is_playing(self, speaker: SpeakerNode) -> bool:
+        """Check if media is actively playing via Cast V2 or Bluetooth A2DP."""
+        # 1. Check local Bluetooth audio streaming (Port 8443)
+        try:
+            if await self._check_bluetooth_streaming(speaker):
+                _LOGGER.debug("Speaker %s is playing audio via Bluetooth", speaker.name)
+                return True
+        except Exception as err:
+            _LOGGER.debug("Failed checking Bluetooth status on %s: %s", speaker.name, err)
+
+        # 2. Check Cast V2 socket streaming (Port 8009)
+        try:
+            if await self._check_cast_playing(speaker):
+                _LOGGER.debug("Speaker %s is actively casting media", speaker.name)
+                return True
+        except Exception as err:
+            _LOGGER.debug("Failed checking Cast playback on %s: %s", speaker.name, err)
+
+        return False
+
+    async def _check_bluetooth_streaming(self, speaker: SpeakerNode) -> bool:
+        """Query local HTTPS port 8443 for connected Bluetooth devices."""
+        status = await self._api_client.get_bluetooth_status(speaker)
+        connected_devices = status.get("connected_devices", [])
+        return bool(connected_devices)
+
+    async def _check_cast_playing(self, speaker: SpeakerNode) -> bool:
+        """Run blocking pychromecast socket check in executor thread."""
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            None,
+            self._sync_check_cast,
+            speaker.ip_address,
+            speaker.hardware,
+            speaker.name,
+        )
+
+    def _sync_check_cast(self, host: str, hardware: str, name: str) -> bool:
+        """Query Cast V2 receiver and media controller status."""
+        cast: pychromecast.Chromecast | None = None
+        try:
+            cast_info = CastInfo(
+                services={HostServiceInfo(host, 8009)},
+                uuid=uuid.uuid4(),
+                model_name=hardware,
+                friendly_name=name,
+                host=host,
+                port=8009,
+                cast_type="audio",
+                manufacturer="Google Inc.",
+            )
+            cast = pychromecast.Chromecast(
+                cast_info=cast_info,
+                tries=1,
+                timeout=self._cast_timeout,
+            )
+            cast.wait(timeout=self._cast_timeout)
+
+            # Check media controller player state
+            if cast.media_controller and cast.media_controller.status:
+                state = cast.media_controller.status.player_state
+                if state in ACTIVE_PLAYER_STATES:
+                    return True
+
+            return False
+        except Exception as err:
+            _LOGGER.debug("Error probing Cast V2 status on %s: %s", host, err)
+            return False
+        finally:
+            if cast is not None:
+                try:
+                    cast.disconnect()
+                except Exception:
+                    pass

--- a/custom_components/google_home_bt_proxy/strings.json
+++ b/custom_components/google_home_bt_proxy/strings.json
@@ -30,8 +30,12 @@
       "init": {
         "title": "Bluetooth Proxy Settings",
         "data": {
-          "scan_timeout": "Hardware Scan Duration (seconds)",
-          "scan_interval": "Interval Between Scans (seconds)",
+          "playback_mode": "Media Playback Handling Mode",
+          "scan_timeout": "Idle Scan Duration (seconds)",
+          "scan_interval": "Idle Scan Interval (seconds)",
+          "playing_scan_timeout": "Playback Scan Duration (seconds)",
+          "playing_scan_interval": "Playback Scan Interval (seconds)",
+          "max_playing_skip_duration": "Max Continuous Playback Skip Ceiling (seconds)",
           "rssi_threshold": "Minimum RSSI Threshold (dBm)"
         }
       }

--- a/docs/superpowers/plans/2026-09-06-playback-aware-scanning.md
+++ b/docs/superpowers/plans/2026-09-06-playback-aware-scanning.md
@@ -1,0 +1,330 @@
+# Standalone Playback-Aware Scanning Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement standalone playback-aware Bluetooth scanning with configurable intervals, durations, and skip ceilings in `ha-google-home-bt-proxy` without any dependency on Home Assistant's `cast` component or `media_player` entities.
+
+**Architecture:** A standalone `SpeakerPlaybackDetector` queries the speaker directly via Cast V2 TLS (port 8009) and local Bluetooth status HTTPS (port 8443). The worker scan loop in `_speaker_scan_loop` adapts between idle cadence, throttled cadence, or skip-with-ceiling based on the active playback mode and configurable timing options.
+
+**Tech Stack:** Python 3.12+, `aiohttp`, `pychromecast`, `homeassistant`, `pytest`, `pytest-asyncio`, `ruff`, `mypy`.
+
+## Global Constraints
+
+- Repository: `/drives/nfs/repos/ha-google-home-bt-proxy`
+- Branch: `feat/playback-aware-scanning`
+- Zero external runtime daemons or Home Assistant `cast` component coupling; 100% standalone direct speaker communication.
+- Adhere strictly to Steven T. Pelech's `AgenticEngineeringToolbelt` standards: SOLID, role-based naming, $\ge$ 80% test coverage, 4-stage quality gates.
+
+---
+
+### Task 1: Constants and Configuration Keys (`const.py`, `strings.json`)
+
+**Files:**
+- Modify: `custom_components/google_home_bt_proxy/const.py`
+- Modify: `custom_components/google_home_bt_proxy/strings.json`
+- Test: `tests/test_models.py`
+
+**Interfaces:**
+- Produces in `const.py`:
+  - `CONF_PLAYBACK_MODE: Final = "playback_mode"`
+  - `MODE_THROTTLE: Final = "throttle"`
+  - `MODE_SKIP_CEILING: Final = "skip_ceiling"`
+  - `MODE_IGNORE: Final = "ignore"`
+  - `CONF_PLAYING_SCAN_TIMEOUT: Final = "playing_scan_timeout"`
+  - `CONF_PLAYING_SCAN_INTERVAL: Final = "playing_scan_interval"`
+  - `CONF_MAX_PLAYING_SKIP_DURATION: Final = "max_playing_skip_duration"`
+  - `DEFAULT_PLAYBACK_MODE: Final = MODE_THROTTLE`
+  - `DEFAULT_PLAYING_SCAN_TIMEOUT: Final = 2`
+  - `DEFAULT_PLAYING_SCAN_INTERVAL: Final = 30`
+  - `DEFAULT_MAX_PLAYING_SKIP_DURATION: Final = 120`
+
+- [ ] **Step 1: Write failing constants test**
+
+Add to `tests/test_models.py`:
+```python
+def test_playback_constants():
+    from custom_components.google_home_bt_proxy.const import (
+        CONF_MAX_PLAYING_SKIP_DURATION,
+        CONF_PLAYBACK_MODE,
+        CONF_PLAYING_SCAN_INTERVAL,
+        CONF_PLAYING_SCAN_TIMEOUT,
+        DEFAULT_MAX_PLAYING_SKIP_DURATION,
+        DEFAULT_PLAYBACK_MODE,
+        DEFAULT_PLAYING_SCAN_INTERVAL,
+        DEFAULT_PLAYING_SCAN_TIMEOUT,
+        MODE_IGNORE,
+        MODE_SKIP_CEILING,
+        MODE_THROTTLE,
+    )
+    assert CONF_PLAYBACK_MODE == "playback_mode"
+    assert MODE_THROTTLE == "throttle"
+    assert MODE_SKIP_CEILING == "skip_ceiling"
+    assert MODE_IGNORE == "ignore"
+    assert DEFAULT_PLAYBACK_MODE == MODE_THROTTLE
+    assert DEFAULT_PLAYING_SCAN_TIMEOUT == 2
+    assert DEFAULT_PLAYING_SCAN_INTERVAL == 30
+    assert DEFAULT_MAX_PLAYING_SKIP_DURATION == 120
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_models.py -k test_playback_constants -v`
+Expected: FAIL with `ImportError`
+
+- [ ] **Step 3: Implement constants in `const.py` and labels in `strings.json`**
+
+Update `custom_components/google_home_bt_proxy/const.py` with the constants.
+Update `custom_components/google_home_bt_proxy/strings.json` with field descriptions and options titles.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_models.py -k test_playback_constants -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add custom_components/google_home_bt_proxy/const.py custom_components/google_home_bt_proxy/strings.json tests/test_models.py
+git commit -m "feat(const): add playback awareness configuration constants and options strings"
+```
+
+---
+
+### Task 2: API Client Bluetooth Status Query (`api.py`)
+
+**Files:**
+- Modify: `custom_components/google_home_bt_proxy/api.py`
+- Test: `tests/test_api.py`
+
+**Interfaces:**
+- Produces in `GoogleHomeApiClient`:
+  - `async def get_bluetooth_status(self, speaker: SpeakerNode) -> dict[str, Any]`
+
+- [ ] **Step 1: Write failing test for `get_bluetooth_status`**
+
+Add to `tests/test_api.py`:
+```python
+@pytest.mark.asyncio
+async def test_get_bluetooth_status(aiohttp_client):
+    async def handle_status(request):
+        assert request.headers.get("cast-local-authorization-token") == "test-token"
+        return web.json_response({
+            "connected_devices": [
+                {"mac_address": "11:22:33:44:55:66", "name": "Phone", "device_class": 5898764}
+            ]
+        })
+
+    app = web.Application()
+    app.router.add_get("/setup/bluetooth/status", handle_status)
+    client = await aiohttp_client(app)
+    api_client = GoogleHomeApiClient(client.session, port=client.server.port, use_ssl=False)
+
+    speaker = SpeakerNode(
+        device_id="test-spk",
+        name="Test Speaker",
+        ip_address=str(client.server.host),
+        auth_token="test-token",
+    )
+
+    status = await api_client.get_bluetooth_status(speaker)
+    assert "connected_devices" in status
+    assert len(status["connected_devices"]) == 1
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_api.py -k test_get_bluetooth_status -v`
+Expected: FAIL with `AttributeError: 'GoogleHomeApiClient' object has no attribute 'get_bluetooth_status'`
+
+- [ ] **Step 3: Implement `get_bluetooth_status` in `api.py`**
+
+Add `get_bluetooth_status` to `GoogleHomeApiClient` using `ENDPOINT_BLUETOOTH_STATUS`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_api.py -k test_get_bluetooth_status -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add custom_components/google_home_bt_proxy/api.py tests/test_api.py
+git commit -m "feat(api): add get_bluetooth_status endpoint query method"
+```
+
+---
+
+### Task 3: Standalone Playback Detector (`playback.py`)
+
+**Files:**
+- Create: `custom_components/google_home_bt_proxy/playback.py`
+- Test: `tests/test_playback.py`
+
+**Interfaces:**
+- Consumes: `SpeakerNode`, `GoogleHomeApiClient`.
+- Produces in `playback.py`:
+  - `class SpeakerPlaybackDetector`:
+    - `def __init__(self, api_client: GoogleHomeApiClient, cast_timeout: float = 3.0) -> None`
+    - `async def async_is_playing(self, speaker: SpeakerNode) -> bool`
+    - `async def _check_cast_playing(self, host: str) -> bool`
+    - `async def _check_bluetooth_streaming(self, speaker: SpeakerNode) -> bool`
+
+- [ ] **Step 1: Write failing playback detector tests**
+
+Create `tests/test_playback.py` testing:
+1. `test_is_playing_cast_active`: Mock pychromecast returning `player_state = "PLAYING"` -> returns `True`.
+2. `test_is_playing_bluetooth_a2dp`: Cast returns `False`, but `/setup/bluetooth/status` returns connected devices with device class or connection -> returns `True`.
+3. `test_is_playing_idle`: Both Cast and BT status report idle -> returns `False`.
+4. `test_is_playing_error_resilience`: Cast socket timeout and BT connection error -> gracefully returns `False`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_playback.py -v`
+Expected: FAIL with `ModuleNotFoundError`
+
+- [ ] **Step 3: Implement `playback.py`**
+
+Implement `SpeakerPlaybackDetector` with direct socket/pychromecast queries and `api_client.get_bluetooth_status` checks, wrapped in safe timeouts (`asyncio.timeout` / executor).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_playback.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add custom_components/google_home_bt_proxy/playback.py tests/test_playback.py
+git commit -m "feat(playback): implement standalone SpeakerPlaybackDetector for Cast and Bluetooth audio"
+```
+
+---
+
+### Task 4: Options Flow Playback Configuration (`config_flow.py`)
+
+**Files:**
+- Modify: `custom_components/google_home_bt_proxy/config_flow.py`
+- Test: `tests/test_config_flow.py`
+
+**Interfaces:**
+- Produces: Updated `GoogleHomeBtProxyOptionsFlowHandler` supporting `playback_mode`, `scan_timeout`, `scan_interval`, `playing_scan_timeout`, `playing_scan_interval`, `max_playing_skip_duration`, and `rssi_threshold`.
+
+- [ ] **Step 1: Write failing options flow test**
+
+Add to `tests/test_config_flow.py`:
+```python
+@pytest.mark.asyncio
+async def test_options_flow_with_playback_settings():
+    from custom_components.google_home_bt_proxy.const import (
+        CONF_PLAYBACK_MODE,
+        CONF_PLAYING_SCAN_INTERVAL,
+        CONF_PLAYING_SCAN_TIMEOUT,
+        CONF_MAX_PLAYING_SKIP_DURATION,
+        MODE_SKIP_CEILING,
+    )
+    entry = MagicMock()
+    entry.options = {}
+    handler = GoogleHomeBtProxyOptionsFlowHandler(entry)
+
+    user_input = {
+        CONF_PLAYBACK_MODE: MODE_SKIP_CEILING,
+        CONF_PLAYING_SCAN_TIMEOUT: 3,
+        CONF_PLAYING_SCAN_INTERVAL: 45,
+        CONF_MAX_PLAYING_SKIP_DURATION: 180,
+    }
+    result = await handler.async_step_init(user_input)
+    assert result["type"] == "create_entry"
+    assert result["data"][CONF_PLAYBACK_MODE] == MODE_SKIP_CEILING
+    assert result["data"][CONF_PLAYING_SCAN_TIMEOUT] == 3
+    assert result["data"][CONF_PLAYING_SCAN_INTERVAL] == 45
+    assert result["data"][CONF_MAX_PLAYING_SKIP_DURATION] == 180
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_config_flow.py -k test_options_flow_with_playback_settings -v`
+Expected: FAIL
+
+- [ ] **Step 3: Update `config_flow.py` options schema**
+
+Add `vol.Optional(CONF_PLAYBACK_MODE, default=...)`, `CONF_PLAYING_SCAN_TIMEOUT`, `CONF_PLAYING_SCAN_INTERVAL`, `CONF_MAX_PLAYING_SKIP_DURATION` with validation ranges.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_config_flow.py -k test_options_flow_with_playback_settings -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add custom_components/google_home_bt_proxy/config_flow.py tests/test_config_flow.py
+git commit -m "feat(flow): add playback mode, playing timings, and skip ceiling to options flow"
+```
+
+---
+
+### Task 5: Adaptive Playback Scan Loop & State Machine (`__init__.py`)
+
+**Files:**
+- Modify: `custom_components/google_home_bt_proxy/__init__.py`
+- Test: `tests/test_init.py`
+
+**Interfaces:**
+- Consumes: `SpeakerPlaybackDetector`, `CONF_PLAYBACK_MODE`, `CONF_PLAYING_SCAN_INTERVAL`, `CONF_PLAYING_SCAN_TIMEOUT`, `CONF_MAX_PLAYING_SKIP_DURATION`.
+- Modifies: `_speaker_scan_loop` in `__init__.py`.
+
+- [ ] **Step 1: Write failing tests for adaptive scan loop**
+
+Add tests to `tests/test_init.py`:
+1. `test_scan_loop_throttles_when_playing`: When `playback_mode == "throttle"` and `async_is_playing` is True, verify scan timeout is 2s and interval is 30s.
+2. `test_scan_loop_skips_until_ceiling`: When `playback_mode == "skip_ceiling"` and `async_is_playing` is True, skips scan while duration < ceiling, and triggers scan once duration $\ge$ ceiling.
+3. `test_scan_loop_ignores_playback_in_ignore_mode`: When `playback_mode == "ignore"`, scans with normal idle timeout and interval regardless of playback state.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_init.py -k "playback or throttle or ceiling" -v`
+Expected: FAIL
+
+- [ ] **Step 3: Implement adaptive scan loop in `__init__.py`**
+
+Wire `SpeakerPlaybackDetector` into `_speaker_scan_loop`, calculate active timeout/interval dynamically, track continuous playback skip duration, and enforce the mode policy.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_init.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add custom_components/google_home_bt_proxy/__init__.py tests/test_init.py
+git commit -m "feat(worker): implement adaptive scan loop with playback throttling and skip ceiling"
+```
+
+---
+
+### Task 6: Full Suite Verification, Quality Gates & Pull Request
+
+**Files:**
+- All modified files
+
+- [ ] **Step 1: Run Ruff linter and formatter**
+
+Run: `uv run ruff check . && uv run ruff format --check .`
+
+- [ ] **Step 2: Run Mypy type checker**
+
+Run: `uv run mypy custom_components/ tests/`
+
+- [ ] **Step 3: Run Pytest test suite with code coverage**
+
+Run: `uv run pytest --cov=custom_components.google_home_bt_proxy --cov-report=term-missing`
+Expected: 100% pass, coverage $\ge$ 80%
+
+- [ ] **Step 4: Push branch and create Pull Request**
+
+Run:
+```bash
+git push -u origin feat/playback-aware-scanning
+gh pr create --title "feat: standalone playback-aware Bluetooth scanning with configurable intervals" --body "..."
+```

--- a/docs/superpowers/plans/2026-09-06-playback-aware-scanning.md
+++ b/docs/superpowers/plans/2026-09-06-playback-aware-scanning.md
@@ -56,6 +56,7 @@ def test_playback_constants():
         MODE_SKIP_CEILING,
         MODE_THROTTLE,
     )
+
     assert CONF_PLAYBACK_MODE == "playback_mode"
     assert MODE_THROTTLE == "throttle"
     assert MODE_SKIP_CEILING == "skip_ceiling"
@@ -108,11 +109,13 @@ Add to `tests/test_api.py`:
 async def test_get_bluetooth_status(aiohttp_client):
     async def handle_status(request):
         assert request.headers.get("cast-local-authorization-token") == "test-token"
-        return web.json_response({
-            "connected_devices": [
-                {"mac_address": "11:22:33:44:55:66", "name": "Phone", "device_class": 5898764}
-            ]
-        })
+        return web.json_response(
+            {
+                "connected_devices": [
+                    {"mac_address": "11:22:33:44:55:66", "name": "Phone", "device_class": 5898764}
+                ]
+            }
+        )
 
     app = web.Application()
     app.router.add_get("/setup/bluetooth/status", handle_status)
@@ -222,6 +225,7 @@ async def test_options_flow_with_playback_settings():
         CONF_MAX_PLAYING_SKIP_DURATION,
         MODE_SKIP_CEILING,
     )
+
     entry = MagicMock()
     entry.options = {}
     handler = GoogleHomeBtProxyOptionsFlowHandler(entry)

--- a/docs/superpowers/specs/2026-09-06-playback-aware-scanning-design.md
+++ b/docs/superpowers/specs/2026-09-06-playback-aware-scanning-design.md
@@ -1,0 +1,109 @@
+# Design Specification: Standalone Playback-Aware Bluetooth Scanning
+
+## 1. Objective
+
+Enable `ha-google-home-bt-proxy` to intelligently adapt or suppress Bluetooth inquiry scanning whenever media is actively playing on a Google Home or Nest speaker, while preserving BLE room tracking (Bermuda) freshness via fully configurable intervals, durations, and skip ceilings.
+
+The integration **must stand alone**—it must not depend on Home Assistant's `cast` integration, entity registry, or existing `media_player` entities. All playback detection is performed directly against the speaker's IP address on the local area network.
+
+## 2. Problem Statement & Hardware Constraints
+
+Google Home and Nest speakers (Home Mini, Nest Mini, Nest Audio) use integrated Wi-Fi/Bluetooth combo chipsets sharing 2.4 GHz RF paths and antenna elements. When the speaker executes an active inquiry scan (`POST /setup/bluetooth/scan`), the Bluetooth radio prioritizes channel inquiry:
+1. **Bluetooth Audio (A2DP):** Causes audible audio stutter, buffer underruns, packet drops, or complete disconnects if streaming to or from a paired Bluetooth device.
+2. **Cast Audio over Wi-Fi:** Coexistence contention and CPU load during 5-second inquiry sweeps can produce audible micro-glitches and crackling.
+3. **Tracking Starvation:** If scanning is completely suspended during media playback without a bound, long listening sessions (e.g. 2-hour playlists, podcasts, or white noise) cause Bermuda BLE device tracking to go completely dark.
+
+## 3. Architecture & Standalone Detection
+
+Playback state is queried directly from each physical speaker using two standalone network channels:
+
+```mermaid
+flowchart TD
+    subgraph Speaker["Google Home / Nest Speaker (IP Address)"]
+        CastSocket["Port 8009: Cast V2 TLS Engine"]
+        ApiPort["Port 8443: Local Setup HTTPS Server"]
+    end
+
+    subgraph Integration["custom_components/google_home_bt_proxy"]
+        PlaybackDetector["SpeakerPlaybackDetector (playback.py)"]
+        ApiClient["GoogleHomeApiClient (api.py)"]
+        WorkerLoop["_speaker_scan_loop (__init__.py)"]
+    end
+
+    PlaybackDetector -->|Direct TLS Socket| CastSocket
+    CastSocket -->|media_controller.status.player_state| PlaybackDetector
+
+    PlaybackDetector -->|HTTPS GET /setup/bluetooth/status| ApiClient
+    ApiClient -->|Port 8443| ApiPort
+    ApiPort -->|connected_devices (A2DP stream)| ApiClient
+    ApiClient --> PlaybackDetector
+
+    PlaybackDetector -->|is_playing: bool| WorkerLoop
+    WorkerLoop -->|Adaptive Interval & Timeout| ApiClient
+```
+
+### 3.1 Source A: Standalone Cast V2 Socket (Port 8009)
+* Connects directly to `speaker.ip_address:8009` via `pychromecast`.
+* Inspects `media_controller.status.player_state` (`PLAYING`, `BUFFERING`) and `cast.status.display_name` (detects active streaming applications such as Spotify, YouTube Music, TuneIn, TTS vs. idle backdrop).
+* Operates completely out-of-band from Home Assistant's `cast` component.
+
+### 3.2 Source B: Bluetooth Audio Status (Port 8443)
+* Queries `GET https://{speaker.ip_address}:8443/setup/bluetooth/status` with `cast-local-authorization-token`.
+* Inspects `connected_devices` for active A2DP audio profiles.
+
+### 3.3 Evaluation Logic
+If either Source A (Cast) or Source B (Bluetooth A2DP) indicates active media playback, `SpeakerPlaybackDetector.async_is_playing(speaker)` returns `True`. If both are idle or connection checks fail/time out, it safely falls back to `False`.
+
+## 4. Playback Modes & Adaptive Scanning
+
+The integration exposes three user-selectable playback modes:
+
+1. **`throttle` (Default):**
+   * While media is playing, continue scanning but at a relaxed cadence and shorter hardware sweep:
+     * Scan Duration: `playing_scan_timeout` (default: 2s)
+     * Scan Interval: `playing_scan_interval` (default: 30s)
+   * Reduces RF contention by >85% while keeping BLE device tracker leases alive.
+2. **`skip_ceiling`:**
+   * While media is playing, completely skip/suppress inquiry scans.
+   * Tracks `continuous_playing_start_time`. If continuous playback exceeds `max_playing_skip_duration` (default: 120s), forces a single rapid scan (`playing_scan_timeout`, 2s) to refresh beacons, then resets the timer.
+3. **`ignore`:**
+   * Unconditionally scans at idle interval/timeout regardless of playback status.
+
+When media stops (transitions to `IDLE` or `PAUSED`), scanning immediately resets to normal idle cadence without waiting for the longer playing interval.
+
+## 5. Configuration & Options Schema
+
+Configured via the Home Assistant Options Flow in `config_flow.py`:
+
+| Parameter Key | Type | Default | Range / Allowed Values | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| `CONF_PLAYBACK_MODE` | `str` | `"throttle"` | `["throttle", "skip_ceiling", "ignore"]` | Policy when media is playing |
+| `CONF_SCAN_TIMEOUT` | `int` | `5` | `2` – `15` seconds | Hardware scan duration when idle |
+| `CONF_SCAN_INTERVAL` | `int` | `10` | `5` – `60` seconds | Wait time between scans when idle |
+| `CONF_PLAYING_SCAN_TIMEOUT`| `int` | `2` | `1` – `10` seconds | Hardware scan duration when playing |
+| `CONF_PLAYING_SCAN_INTERVAL`| `int` | `30` | `10` – `300` seconds | Interval between scans when playing (throttle mode) |
+| `CONF_MAX_PLAYING_SKIP_DURATION`| `int` | `120` | `30` – `900` seconds | Max continuous skip duration before forced scan (skip_ceiling mode) |
+| `CONF_RSSI_THRESHOLD` | `int` | `-90` | `-100` to `-40` dBm | Minimum RSSI filter threshold |
+
+## 6. Implementation Components
+
+1. **`custom_components/google_home_bt_proxy/const.py`**:
+   * Add constants: `CONF_PLAYBACK_MODE`, `MODE_THROTTLE`, `MODE_SKIP_CEILING`, `MODE_IGNORE`, `CONF_PLAYING_SCAN_TIMEOUT`, `CONF_PLAYING_SCAN_INTERVAL`, `CONF_MAX_PLAYING_SKIP_DURATION`, `ENDPOINT_BLUETOOTH_STATUS`, and their defaults.
+2. **`custom_components/google_home_bt_proxy/api.py`**:
+   * Add `async def get_bluetooth_status(self, speaker: SpeakerNode) -> dict[str, Any]` to fetch `/setup/bluetooth/status`.
+3. **`custom_components/google_home_bt_proxy/playback.py`**:
+   * Implement `SpeakerPlaybackDetector` to handle standalone Cast V2 queries and Bluetooth status evaluation with timeout resilience.
+4. **`custom_components/google_home_bt_proxy/config_flow.py`**:
+   * Update `GoogleHomeBtProxyOptionsFlowHandler` schema with mode selection and all configurable intervals/durations.
+5. **`custom_components/google_home_bt_proxy/strings.json`**:
+   * Add localized strings and option titles for the new configuration parameters.
+6. **`custom_components/google_home_bt_proxy/__init__.py`**:
+   * Instantiate `SpeakerPlaybackDetector`.
+   * Update `_speaker_scan_loop` state machine with mode evaluation, adaptive intervals, duration switching, and skip ceiling tracking.
+
+## 7. Testing & Quality Assurance
+
+* **`tests/test_playback.py`**: Unit tests verifying `SpeakerPlaybackDetector` correctly identifies Cast playback states, Bluetooth A2DP connections, and handles timeouts/exceptions gracefully.
+* **`tests/test_api.py`**: Test `get_bluetooth_status` endpoint query and response handling.
+* **`tests/test_config_flow.py`**: Test options flow form rendering, default population, and persistence of all new parameters.
+* **`tests/test_init.py`**: Test `_speaker_scan_loop` behavior across `throttle`, `skip_ceiling` (including ceiling trigger), and `ignore` modes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "homeassistant==2026.1.0",
     "habluetooth>=3.8.0",
     "bluetooth-data-tools>=1.20.0",
+    "pychromecast>=14.0.10",
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ha-google-home-bt-proxy"
-version = "0.1.0"
+version = "0.2.0"
 description = "Home Assistant Google Home Bluetooth Proxy for Bermuda BLE Tracking"
 authors = [{name = "Steven T. Pelech"}]
 license = {text = "MIT"}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -234,3 +234,33 @@ async def test_connection_error_raises_speaker_connection_error() -> None:
         with pytest.raises(SpeakerConnectionError):
             await api_client.get_device_info(speaker)
         assert speaker.available is False
+
+
+@pytest.mark.asyncio
+async def test_get_bluetooth_status(aiohttp_client) -> None:
+    """Verify get_bluetooth_status returns bluetooth status data."""
+    async def handle_status(request: web.Request) -> web.Response:
+        assert request.headers.get("cast-local-authorization-token") == "test-token"
+        return web.json_response({
+            "connected_devices": [
+                {"mac_address": "11:22:33:44:55:66", "name": "Phone", "device_class": 5898764}
+            ]
+        })
+
+    app = web.Application()
+    app.router.add_get("/setup/bluetooth/status", handle_status)
+    client = await aiohttp_client(app)
+    api_client = GoogleHomeApiClient(client.session, port=client.server.port, use_ssl=False)
+
+    speaker = SpeakerNode(
+        device_id="test-spk",
+        name="Test Speaker",
+        ip_address=str(client.server.host),
+        auth_token="test-token",
+    )
+
+    status = await api_client.get_bluetooth_status(speaker)
+    assert "connected_devices" in status
+    assert len(status["connected_devices"]) == 1
+    assert status["connected_devices"][0]["name"] == "Phone"
+

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -239,13 +239,16 @@ async def test_connection_error_raises_speaker_connection_error() -> None:
 @pytest.mark.asyncio
 async def test_get_bluetooth_status(aiohttp_client) -> None:
     """Verify get_bluetooth_status returns bluetooth status data."""
+
     async def handle_status(request: web.Request) -> web.Response:
         assert request.headers.get("cast-local-authorization-token") == "test-token"
-        return web.json_response({
-            "connected_devices": [
-                {"mac_address": "11:22:33:44:55:66", "name": "Phone", "device_class": 5898764}
-            ]
-        })
+        return web.json_response(
+            {
+                "connected_devices": [
+                    {"mac_address": "11:22:33:44:55:66", "name": "Phone", "device_class": 5898764}
+                ]
+            }
+        )
 
     app = web.Application()
     app.router.add_get("/setup/bluetooth/status", handle_status)
@@ -263,4 +266,3 @@ async def test_get_bluetooth_status(aiohttp_client) -> None:
     assert "connected_devices" in status
     assert len(status["connected_devices"]) == 1
     assert status["connected_devices"][0]["name"] == "Phone"
-

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -159,6 +159,45 @@ async def test_options_flow():
 
 
 @pytest.mark.asyncio
+async def test_options_flow_with_playback_settings():
+    """Verify options flow accepts playback mode and timing settings."""
+    from custom_components.google_home_bt_proxy.const import (
+        CONF_MAX_PLAYING_SKIP_DURATION,
+        CONF_PLAYBACK_MODE,
+        CONF_PLAYING_SCAN_INTERVAL,
+        CONF_PLAYING_SCAN_TIMEOUT,
+        MODE_SKIP_CEILING,
+    )
+
+    mock_entry = MagicMock()
+    mock_entry.options = {}
+    handler = GoogleHomeBtProxyOptionsFlowHandler(mock_entry)
+
+    # Show form and verify schema includes new fields
+    form_result = await handler.async_step_init(None)
+    assert form_result["type"] == "form"
+    schema_keys = [k.schema for k in form_result["data_schema"].schema.keys()]
+    assert CONF_PLAYBACK_MODE in schema_keys
+    assert CONF_PLAYING_SCAN_TIMEOUT in schema_keys
+    assert CONF_PLAYING_SCAN_INTERVAL in schema_keys
+    assert CONF_MAX_PLAYING_SKIP_DURATION in schema_keys
+
+    # Submit form
+    user_input = {
+        CONF_PLAYBACK_MODE: MODE_SKIP_CEILING,
+        CONF_PLAYING_SCAN_TIMEOUT: 3,
+        CONF_PLAYING_SCAN_INTERVAL: 45,
+        CONF_MAX_PLAYING_SKIP_DURATION: 180,
+    }
+    create_result = await handler.async_step_init(user_input)
+    assert create_result["type"] == "create_entry"
+    assert create_result["data"][CONF_PLAYBACK_MODE] == MODE_SKIP_CEILING
+    assert create_result["data"][CONF_PLAYING_SCAN_TIMEOUT] == 3
+    assert create_result["data"][CONF_PLAYING_SCAN_INTERVAL] == 45
+    assert create_result["data"][CONF_MAX_PLAYING_SKIP_DURATION] == 180
+
+
+@pytest.mark.asyncio
 async def test_options_flow_fallback_config_entry():
     handler = GoogleHomeBtProxyOptionsFlowHandler.__new__(GoogleHomeBtProxyOptionsFlowHandler)
     mock_entry = MagicMock()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -170,6 +170,8 @@ async def test_speaker_scan_loop_normal_cycle():
         auth_token="token123",
     )
     mock_scanner = MagicMock()
+    mock_detector = MagicMock()
+    mock_detector.async_is_playing = AsyncMock(return_value=False)
 
     loop_task = asyncio.create_task(
         _speaker_scan_loop(
@@ -180,6 +182,7 @@ async def test_speaker_scan_loop_normal_cycle():
             mock_speaker,
             mock_scanner,
             initial_delay=0.01,
+            playback_detector=mock_detector,
         )
     )
 
@@ -214,6 +217,8 @@ async def test_speaker_scan_loop_token_expired():
         auth_token="old-token",
     )
     mock_scanner = MagicMock()
+    mock_detector = MagicMock()
+    mock_detector.async_is_playing = AsyncMock(return_value=False)
 
     with patch("asyncio.sleep", AsyncMock()) as mock_sleep:
         # Stop loop after one sleep call in TokenExpiredError
@@ -228,6 +233,7 @@ async def test_speaker_scan_loop_token_expired():
                 mock_speaker,
                 mock_scanner,
                 initial_delay=0.0,
+                playback_detector=mock_detector,
             )
 
     mock_coord.async_refresh_token.assert_called_once_with(mock_speaker)
@@ -256,6 +262,8 @@ async def test_speaker_scan_loop_connection_error_and_generic_error():
         auth_token="test-token",
     )
     mock_scanner = MagicMock()
+    mock_detector = MagicMock()
+    mock_detector.async_is_playing = AsyncMock(return_value=False)
 
     with patch("asyncio.sleep", AsyncMock()):
         with pytest.raises(asyncio.CancelledError):
@@ -267,6 +275,177 @@ async def test_speaker_scan_loop_connection_error_and_generic_error():
                 mock_speaker,
                 mock_scanner,
                 initial_delay=0.0,
+                playback_detector=mock_detector,
             )
 
     assert mock_api.start_scan.call_count >= 2
+
+
+@pytest.mark.asyncio
+async def test_speaker_scan_loop_playback_throttle():
+    """Verify scan loop throttles scan timeout and interval when playing."""
+    from custom_components.google_home_bt_proxy.const import (
+        CONF_PLAYBACK_MODE,
+        CONF_PLAYING_SCAN_INTERVAL,
+        CONF_PLAYING_SCAN_TIMEOUT,
+        MODE_THROTTLE,
+    )
+
+    mock_hass = MagicMock()
+    mock_entry = MagicMock()
+    mock_entry.options = {
+        CONF_PLAYBACK_MODE: MODE_THROTTLE,
+        CONF_PLAYING_SCAN_TIMEOUT: 2,
+        CONF_PLAYING_SCAN_INTERVAL: 30,
+    }
+
+    mock_coord = MagicMock()
+    mock_api = MagicMock()
+    mock_api.start_scan = AsyncMock(return_value=True)
+    mock_api.get_scan_results = AsyncMock(return_value=[])
+
+    mock_speaker = SpeakerNode(
+        device_id="spk-test",
+        name="Living Room",
+        ip_address="192.168.1.100",
+        auth_token="test-token",
+    )
+    mock_scanner = MagicMock()
+
+    mock_detector = MagicMock()
+    mock_detector.async_is_playing = AsyncMock(return_value=True)
+
+    with patch("asyncio.sleep", AsyncMock()) as mock_sleep:
+        mock_sleep.side_effect = [None, None, asyncio.CancelledError()]
+
+        with pytest.raises(asyncio.CancelledError):
+            await _speaker_scan_loop(
+                mock_hass,
+                mock_entry,
+                mock_coord,
+                mock_api,
+                mock_speaker,
+                mock_scanner,
+                initial_delay=0.0,
+                playback_detector=mock_detector,
+            )
+
+    # Started scan with playing timeout
+    mock_api.start_scan.assert_called_once_with(mock_speaker, timeout=2)
+    # Slept for playing timeout and then playing interval
+    mock_sleep.assert_any_call(2)
+    mock_sleep.assert_any_call(30)
+
+
+@pytest.mark.asyncio
+async def test_speaker_scan_loop_playback_skip_ceiling():
+    """Verify skip ceiling skips scans until elapsed duration exceeds max ceiling."""
+    from custom_components.google_home_bt_proxy.const import (
+        CONF_MAX_PLAYING_SKIP_DURATION,
+        CONF_PLAYBACK_MODE,
+        CONF_PLAYING_SCAN_TIMEOUT,
+        MODE_SKIP_CEILING,
+    )
+
+    mock_hass = MagicMock()
+    mock_entry = MagicMock()
+    mock_entry.options = {
+        CONF_PLAYBACK_MODE: MODE_SKIP_CEILING,
+        CONF_PLAYING_SCAN_TIMEOUT: 2,
+        CONF_MAX_PLAYING_SKIP_DURATION: 120,
+    }
+
+    mock_coord = MagicMock()
+    mock_api = MagicMock()
+    mock_api.start_scan = AsyncMock(return_value=True)
+    mock_api.get_scan_results = AsyncMock(return_value=[])
+
+    mock_speaker = SpeakerNode(
+        device_id="spk-test",
+        name="Living Room",
+        ip_address="192.168.1.100",
+        auth_token="test-token",
+    )
+    mock_scanner = MagicMock()
+
+    mock_detector = MagicMock()
+    mock_detector.async_is_playing = AsyncMock(return_value=True)
+
+    # Simulate two cycles: cycle 1 elapsed = 0s (skipped), cycle 2 elapsed = 130s (forced scan)
+    with (
+        patch("time.monotonic", side_effect=[100.0, 230.0, 230.0, 230.0]),
+        patch("asyncio.sleep", AsyncMock()) as mock_sleep,
+    ):
+        mock_sleep.side_effect = [None, None, None, asyncio.CancelledError()]
+
+        with pytest.raises(asyncio.CancelledError):
+            await _speaker_scan_loop(
+                mock_hass,
+                mock_entry,
+                mock_coord,
+                mock_api,
+                mock_speaker,
+                mock_scanner,
+                initial_delay=0.0,
+                playback_detector=mock_detector,
+            )
+
+    # Forced scan was called on cycle 2 with playing timeout
+    mock_api.start_scan.assert_called_once_with(mock_speaker, timeout=2)
+
+
+@pytest.mark.asyncio
+async def test_speaker_scan_loop_playback_ignore():
+    """Verify ignore mode scans with idle settings even when media is playing."""
+    from custom_components.google_home_bt_proxy.const import (
+        CONF_PLAYBACK_MODE,
+        CONF_SCAN_INTERVAL,
+        CONF_SCAN_TIMEOUT,
+        MODE_IGNORE,
+    )
+
+    mock_hass = MagicMock()
+    mock_entry = MagicMock()
+    mock_entry.options = {
+        CONF_PLAYBACK_MODE: MODE_IGNORE,
+        CONF_SCAN_TIMEOUT: 5,
+        CONF_SCAN_INTERVAL: 10,
+    }
+
+    mock_coord = MagicMock()
+    mock_api = MagicMock()
+    mock_api.start_scan = AsyncMock(return_value=True)
+    mock_api.get_scan_results = AsyncMock(return_value=[])
+
+    mock_speaker = SpeakerNode(
+        device_id="spk-test",
+        name="Living Room",
+        ip_address="192.168.1.100",
+        auth_token="test-token",
+    )
+    mock_scanner = MagicMock()
+
+    mock_detector = MagicMock()
+    mock_detector.async_is_playing = AsyncMock(return_value=True)
+
+    with patch("asyncio.sleep", AsyncMock()) as mock_sleep:
+        mock_sleep.side_effect = [None, None, asyncio.CancelledError()]
+
+        with pytest.raises(asyncio.CancelledError):
+            await _speaker_scan_loop(
+                mock_hass,
+                mock_entry,
+                mock_coord,
+                mock_api,
+                mock_speaker,
+                mock_scanner,
+                initial_delay=0.0,
+                playback_detector=mock_detector,
+            )
+
+    # detector.async_is_playing should NOT be called in ignore mode
+    mock_detector.async_is_playing.assert_not_called()
+    mock_api.start_scan.assert_called_once_with(mock_speaker, timeout=5)
+    mock_sleep.assert_any_call(5)
+    mock_sleep.assert_any_call(10)
+

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -448,4 +448,3 @@ async def test_speaker_scan_loop_playback_ignore():
     mock_api.start_scan.assert_called_once_with(mock_speaker, timeout=5)
     mock_sleep.assert_any_call(5)
     mock_sleep.assert_any_call(10)
-

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -39,3 +39,30 @@ def test_discovered_device_model():
     assert dev.mac_address == "AA:BB:CC:DD:EE:FF"
     assert dev.rssi == -72
     assert dev.name == "Tile Beacon"
+
+
+def test_playback_constants():
+    """Verify playback configuration constants and defaults."""
+    from custom_components.google_home_bt_proxy.const import (
+        CONF_MAX_PLAYING_SKIP_DURATION,
+        CONF_PLAYBACK_MODE,
+        CONF_PLAYING_SCAN_INTERVAL,
+        CONF_PLAYING_SCAN_TIMEOUT,
+        DEFAULT_MAX_PLAYING_SKIP_DURATION,
+        DEFAULT_PLAYBACK_MODE,
+        DEFAULT_PLAYING_SCAN_INTERVAL,
+        DEFAULT_PLAYING_SCAN_TIMEOUT,
+        MODE_IGNORE,
+        MODE_SKIP_CEILING,
+        MODE_THROTTLE,
+    )
+
+    assert CONF_PLAYBACK_MODE == "playback_mode"
+    assert MODE_THROTTLE == "throttle"
+    assert MODE_SKIP_CEILING == "skip_ceiling"
+    assert MODE_IGNORE == "ignore"
+    assert DEFAULT_PLAYBACK_MODE == MODE_THROTTLE
+    assert DEFAULT_PLAYING_SCAN_TIMEOUT == 2
+    assert DEFAULT_PLAYING_SCAN_INTERVAL == 30
+    assert DEFAULT_MAX_PLAYING_SKIP_DURATION == 120
+

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -58,6 +58,9 @@ def test_playback_constants():
     )
 
     assert CONF_PLAYBACK_MODE == "playback_mode"
+    assert CONF_PLAYING_SCAN_TIMEOUT == "playing_scan_timeout"
+    assert CONF_PLAYING_SCAN_INTERVAL == "playing_scan_interval"
+    assert CONF_MAX_PLAYING_SKIP_DURATION == "max_playing_skip_duration"
     assert MODE_THROTTLE == "throttle"
     assert MODE_SKIP_CEILING == "skip_ceiling"
     assert MODE_IGNORE == "ignore"
@@ -65,4 +68,3 @@ def test_playback_constants():
     assert DEFAULT_PLAYING_SCAN_TIMEOUT == 2
     assert DEFAULT_PLAYING_SCAN_INTERVAL == 30
     assert DEFAULT_MAX_PLAYING_SKIP_DURATION == 120
-

--- a/tests/test_playback.py
+++ b/tests/test_playback.py
@@ -70,7 +70,11 @@ async def test_is_playing_handles_exceptions_gracefully(speaker, mock_api_client
     mock_api_client.get_bluetooth_status.side_effect = Exception("API connection dropped")
     detector = SpeakerPlaybackDetector(mock_api_client, cast_timeout=1.0)
 
-    with patch.object(detector, "_check_cast_playing", AsyncMock(side_effect=Exception("Cast socket timeout"))):
+    with patch.object(
+        detector,
+        "_check_cast_playing",
+        AsyncMock(side_effect=Exception("Cast socket timeout")),
+    ):
         is_playing = await detector.async_is_playing(speaker)
         assert is_playing is False
 

--- a/tests/test_playback.py
+++ b/tests/test_playback.py
@@ -1,0 +1,87 @@
+"""Tests for SpeakerPlaybackDetector."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.google_home_bt_proxy.models import SpeakerNode
+from custom_components.google_home_bt_proxy.playback import SpeakerPlaybackDetector
+
+
+@pytest.fixture
+def speaker() -> SpeakerNode:
+    return SpeakerNode(
+        device_id="spk-123",
+        name="Living Room Speaker",
+        ip_address="192.168.1.50",
+        auth_token="token-abc",
+    )
+
+
+@pytest.fixture
+def mock_api_client() -> MagicMock:
+    client = MagicMock()
+    client.get_bluetooth_status = AsyncMock(return_value={"connected_devices": []})
+    return client
+
+
+@pytest.mark.asyncio
+async def test_is_playing_returns_true_when_cast_playing(speaker, mock_api_client) -> None:
+    """Verify returns True when Cast V2 reports MEDIA_PLAYER_STATE_PLAYING."""
+    detector = SpeakerPlaybackDetector(mock_api_client, cast_timeout=1.0)
+
+    with patch.object(detector, "_check_cast_playing", AsyncMock(return_value=True)):
+        is_playing = await detector.async_is_playing(speaker)
+        assert is_playing is True
+
+
+@pytest.mark.asyncio
+async def test_is_playing_returns_true_when_bluetooth_streaming(speaker, mock_api_client) -> None:
+    """Verify returns True when local Bluetooth status has connected streaming devices."""
+    mock_api_client.get_bluetooth_status.return_value = {
+        "connected_devices": [
+            {"mac_address": "AA:BB:CC:DD:EE:FF", "name": "Pixel 8", "device_class": 5898764}
+        ]
+    }
+    detector = SpeakerPlaybackDetector(mock_api_client, cast_timeout=1.0)
+
+    with patch.object(detector, "_check_cast_playing", AsyncMock(return_value=False)):
+        is_playing = await detector.async_is_playing(speaker)
+        assert is_playing is True
+        mock_api_client.get_bluetooth_status.assert_called_once_with(speaker)
+
+
+@pytest.mark.asyncio
+async def test_is_playing_returns_false_when_idle(speaker, mock_api_client) -> None:
+    """Verify returns False when both Cast and Bluetooth are idle."""
+    mock_api_client.get_bluetooth_status.return_value = {"connected_devices": []}
+    detector = SpeakerPlaybackDetector(mock_api_client, cast_timeout=1.0)
+
+    with patch.object(detector, "_check_cast_playing", AsyncMock(return_value=False)):
+        is_playing = await detector.async_is_playing(speaker)
+        assert is_playing is False
+
+
+@pytest.mark.asyncio
+async def test_is_playing_handles_exceptions_gracefully(speaker, mock_api_client) -> None:
+    """Verify returns False gracefully on network errors or unexpected exceptions."""
+    mock_api_client.get_bluetooth_status.side_effect = Exception("API connection dropped")
+    detector = SpeakerPlaybackDetector(mock_api_client, cast_timeout=1.0)
+
+    with patch.object(detector, "_check_cast_playing", AsyncMock(side_effect=Exception("Cast socket timeout"))):
+        is_playing = await detector.async_is_playing(speaker)
+        assert is_playing is False
+
+
+def test_sync_check_cast_detects_playback(speaker, mock_api_client) -> None:
+    """Verify _sync_check_cast inspects media_controller status."""
+    detector = SpeakerPlaybackDetector(mock_api_client, cast_timeout=1.0)
+
+    mock_cast = MagicMock()
+    mock_cast.media_controller.status.player_state = "PLAYING"
+
+    with patch("pychromecast.Chromecast", return_value=mock_cast):
+        assert detector._sync_check_cast(speaker.ip_address, speaker.hardware, speaker.name) is True
+        mock_cast.disconnect.assert_called_once()

--- a/tests/test_simulation_harness.py
+++ b/tests/test_simulation_harness.py
@@ -169,6 +169,9 @@ async def test_scan_loop_closed_loop_token_refresh(aiohttp_client) -> None:
     async def fast_sleep(delay: float) -> None:
         await real_sleep(min(delay, 0.01))
 
+    mock_detector = MagicMock()
+    mock_detector.async_is_playing = AsyncMock(return_value=False)
+
     with patch("asyncio.sleep", side_effect=fast_sleep):
         loop_task = asyncio.create_task(
             _speaker_scan_loop(
@@ -179,6 +182,7 @@ async def test_scan_loop_closed_loop_token_refresh(aiohttp_client) -> None:
                 speaker,
                 scanner,
                 initial_delay=0.0,
+                playback_detector=mock_detector,
             )
         )
 

--- a/uv.lock
+++ b/uv.lock
@@ -632,6 +632,18 @@ wheels = [
 ]
 
 [[package]]
+name = "casttube"
+version = "0.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/54/f7e80d701c587940cf1c871fb6327b4a2682df4287896fbf9400cd0bbf21/casttube-0.2.1.tar.gz", hash = "sha256:54d2af8c7949aa9c5db87fb11ef0a478a5d3e7ac6d2d2ac8dd1711e3a516fc82", size = 5182, upload-time = "2020-04-08T12:54:07.745Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/d2/0f5006892e07ea342d57dbeda46027e99a097ffb6218bee1e37f9776ed95/casttube-0.2.1-py3-none-any.whl", hash = "sha256:36f118007f9eead3959cf30de03c1640b53a263569ff2a3971c0521826c835b2", size = 6513, upload-time = "2020-04-08T12:54:06.107Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.7.22"
 source = { registry = "https://pypi.org/simple" }
@@ -1371,6 +1383,7 @@ dependencies = [
     { name = "glocaltokens" },
     { name = "habluetooth" },
     { name = "homeassistant" },
+    { name = "pychromecast" },
 ]
 
 [package.dev-dependencies]
@@ -1389,6 +1402,7 @@ requires-dist = [
     { name = "glocaltokens", specifier = ">=0.7.6" },
     { name = "habluetooth", specifier = ">=3.8.0" },
     { name = "homeassistant", specifier = "==2026.1.0" },
+    { name = "pychromecast", specifier = ">=14.0.10" },
 ]
 
 [package.metadata.requires-dev]
@@ -2413,6 +2427,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/79/2b2e723d1b929dbe7f99e80a56abb29a4f86988c1f73195d960d706b1629/pycares-4.11.0-cp314-cp314t-win32.whl", hash = "sha256:8a75a406432ce39ce0ca41edff7486df6c970eb0fe5cfbe292f195a6b8654461", size = 122235, upload-time = "2025-09-09T15:17:57.576Z" },
     { url = "https://files.pythonhosted.org/packages/93/fe/bf3b3ed9345a38092e72cd9890a5df5c2349fc27846a714d823a41f0ee27/pycares-4.11.0-cp314-cp314t-win_amd64.whl", hash = "sha256:3784b80d797bcc2ff2bf3d4b27f46d8516fe1707ff3b82c2580dc977537387f9", size = 148575, upload-time = "2025-09-09T15:17:58.699Z" },
     { url = "https://files.pythonhosted.org/packages/ce/20/c0c5cfcf89725fe533b27bc5f714dc4efa8e782bf697c36f9ddf04ba975d/pycares-4.11.0-cp314-cp314t-win_arm64.whl", hash = "sha256:afc6503adf8b35c21183b9387be64ca6810644ef54c9ef6c99d1d5635c01601b", size = 119690, upload-time = "2025-09-09T15:17:59.809Z" },
+]
+
+[[package]]
+name = "pychromecast"
+version = "14.0.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "casttube" },
+    { name = "protobuf" },
+    { name = "zeroconf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3a/1f/d78497441334d24740cce0a92394c33972a9d6a17b607d0ec976f0f48a35/pychromecast-14.0.10.tar.gz", hash = "sha256:f05a1c8d727d4f104c8c731688053033e05157f2ab81bc8eef50ec0c62f9373c", size = 61588, upload-time = "2026-03-07T16:37:42.833Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/61/f0f176622e2b4df06318a3abb2a27cc4c2fee8d40d7a0db8d60034785c09/pychromecast-14.0.10-py2.py3-none-any.whl", hash = "sha256:f5ea52b1db0edc3019ec72c9f5354c7e77c2564ecd44f809a6d2f4f518a02e67", size = 77467, upload-time = "2026-03-07T16:37:41.527Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1376,7 +1376,7 @@ wheels = [
 
 [[package]]
 name = "ha-google-home-bt-proxy"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "bluetooth-data-tools" },


### PR DESCRIPTION
## Summary
Implements standalone media playback awareness for Google Home and Nest speakers to intelligently adapt or suppress Bluetooth inquiry scanning whenever media is actively playing, preventing audio stutter and stream dropouts.

### Key Capabilities
1. **100% Standalone Detection**:
   - Zero dependency on Home Assistant's `cast` integration or `media_player` entities.
   - Probes Cast V2 TLS directly on port 8009 (`pychromecast`) for active media player states.
   - Probes local Bluetooth HTTPS status on port 8443 for active Bluetooth audio (A2DP) streams.
2. **Three Configurable Playback Modes**:
   - **`throttle`** (Default): Reduces hardware inquiry duration to `playing_scan_timeout` (2s) and relaxes interval to `playing_scan_interval` (30s), cutting RF contention by >85% while keeping BLE tracking active.
   - **`skip_ceiling`**: Completely pauses scanning during music, but forces a single quick scan once continuous playback exceeds `max_playing_skip_duration` (120s) to prevent BLE tracker starvation.
   - **`ignore`**: Traditional continuous scanning regardless of playback status.
3. **Full Interval & Duration Configurability**:
   - Idle Scan Duration (`scan_timeout`, default 5s, range 2-15s)
   - Idle Scan Interval (`scan_interval`, default 10s, range 5-60s)
   - Playback Scan Duration (`playing_scan_timeout`, default 2s, range 1-10s)
   - Playback Scan Interval (`playing_scan_interval`, default 30s, range 10-300s)
   - Max Continuous Skip Ceiling (`max_playing_skip_duration`, default 120s, range 30-900s)
   - Minimum RSSI Threshold (`rssi_threshold`, default -90 dBm)

### Quality & Test Verification
- 93 unit and simulation tests passing.
- 97% overall test coverage enforced.
- Clean Ruff formatting, Ruff linting, and Mypy strict type checking.