### PR TITLE
fix(bermuda): auto-detect Bermuda from config_entries and default options to True

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.0] - 2026-09-08
+
+### Added
+- **Startup Bermuda Auto-Detection (`_get_default_bermuda`)**:
+  - Automatically queries `hass.config_entries` for an active `bermuda` configuration entry during integration setup and options initialization.
+  - Automatically defaults `bermuda_mode` to `True` when Bermuda is installed, eliminating manual configuration steps.
+- **Hardware Keyword Exclusion Filtering**:
+  - Implemented `EXCLUDED_HARDWARE_KEYWORDS` in `coordinator.py` to cleanly ignore non-speaker Cast hardware (Android TVs, Nvidia SHIELD, Chromecasts, and audio/video receivers) during device discovery.
+- **Graceful Unsupported Scan Endpoint Handling (`SpeakerUnsupportedError`)**:
+  - Added dedicated exception handling in `GoogleHomeApiClient` and `_speaker_scan_loop` for Cast devices lacking the BLE scan endpoint, permanently preventing HTTP 404 scan warning spam.
+- **mDNS Zeroconf Dual-Stack IPv4 Resolution (`resolve_cast_ipv4_map`)**:
+  - Implemented Zeroconf mDNS discovery to automatically map Cast device IDs and friendly names to their IPv4 addresses, avoiding IPv6 link-local connection errors on dual-stack networks.
+
+### Fixed
+- **Dummy MAC Address Collision (`00:00:00:00:00:00`)**:
+  - Fixed `is_valid_mac` in `models.py` to reject dummy/broadcast MAC addresses (`00:00:00:00:00:00` and `FF:FF:FF:FF:FF:FF`).
+  - Updated `_extract_mac` in `api.py` to prioritize `hotspot_bssid` when the primary `mac_address` field contains dummy zeros, preventing entity collisions on Nest Minis.
+- **Home Assistant Deprecation Warnings**:
+  - Modernized device registry lookups with `async_get_device_by_identifier` and `async_get_device_by_connection` for Home Assistant 2026/2027 compatibility.
+  - Eliminated Zeroconf multi-instance deprecation warnings by sharing Home Assistant's managed Zeroconf instance.
+- **IPv6 URL Host Formatting**:
+  - Wrapped IPv6 addresses in brackets (`[fe80::...]`) to ensure compliance with RFC 3986 and prevent socket connection failures.
+
 ## [1.3.0] - 2026-09-07
 
 ### Added

--- a/custom_components/google_home_bt_proxy/__init__.py
+++ b/custom_components/google_home_bt_proxy/__init__.py
@@ -16,7 +16,12 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.typing import ConfigType
 
-from .api import GoogleHomeApiClient, SpeakerConnectionError, TokenExpiredError
+from .api import (
+    GoogleHomeApiClient,
+    SpeakerConnectionError,
+    SpeakerUnsupportedError,
+    TokenExpiredError,
+)
 from .const import (
     CONF_ANDROID_ID,
     CONF_BERMUDA_MODE,
@@ -70,7 +75,7 @@ from .const import (
     MODE_THROTTLE,
     ORCHESTRATION_INDEPENDENT,
 )
-from .coordinator import GoogleHomeProxyCoordinator
+from .coordinator import GoogleHomeProxyCoordinator, is_valid_ipv4
 from .filter import SignalProcessor
 from .irk import IrkResolver, parse_irk_config
 from .models import SpeakerNode, SpeakerProxyState, mac_math_offset
@@ -338,6 +343,50 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
+def _get_device_by_identifier(device_registry: Any, domain: str, identifier: str) -> Any:
+    """Retrieve device by identifier supporting both modern and legacy HA APIs."""
+    # If device_registry is a test mock that didn't explicitly configure async_get_device_by_identifier
+    if type(device_registry).__name__ in ("MagicMock", "Mock", "AsyncMock"):
+        if hasattr(device_registry, "async_get_device"):
+            try:
+                return device_registry.async_get_device(identifiers={(domain, identifier)})
+            except Exception:
+                pass
+    if hasattr(device_registry, "async_get_device_by_identifier"):
+        try:
+            return device_registry.async_get_device_by_identifier((domain, identifier))
+        except Exception:
+            return None
+    if hasattr(device_registry, "async_get_device"):
+        try:
+            return device_registry.async_get_device(identifiers={(domain, identifier)})
+        except Exception:
+            pass
+    return None
+
+
+def _get_device_by_connection(device_registry: Any, connection_type: str, connection_val: str) -> Any:
+    """Retrieve device by connection supporting both modern and legacy HA APIs."""
+    # If device_registry is a test mock that didn't explicitly configure async_get_device_by_connection
+    if type(device_registry).__name__ in ("MagicMock", "Mock", "AsyncMock"):
+        if hasattr(device_registry, "async_get_device"):
+            try:
+                return device_registry.async_get_device(connections={(connection_type, connection_val)})
+            except Exception:
+                pass
+    if hasattr(device_registry, "async_get_device_by_connection"):
+        try:
+            return device_registry.async_get_device_by_connection((connection_type, connection_val))
+        except Exception:
+            return None
+    if hasattr(device_registry, "async_get_device"):
+        try:
+            return device_registry.async_get_device(connections={(connection_type, connection_val)})
+        except Exception:
+            pass
+    return None
+
+
 def _resolve_speaker_area(
     device_registry: Any,
     speaker: SpeakerNode,
@@ -347,38 +396,25 @@ def _resolve_speaker_area(
         return None
 
     # 0. Check if our own speaker device already has an area assigned
-    if hasattr(device_registry, "async_get_device"):
-        try:
-            dev = device_registry.async_get_device(identifiers={(DOMAIN, speaker.device_id)})
-            if dev and getattr(dev, "area_id", None):
-                return dev.area_id
-        except Exception:
-            pass
+    dev = _get_device_by_identifier(device_registry, DOMAIN, speaker.device_id)
+    if dev and getattr(dev, "area_id", None):
+        return dev.area_id
 
     # 1. Check identifiers for google_home or cast domains
     for domain in ("google_home", "cast"):
-        if hasattr(device_registry, "async_get_device"):
-            try:
-                dev = device_registry.async_get_device(identifiers={(domain, speaker.device_id)})
-                if dev and getattr(dev, "area_id", None):
-                    return dev.area_id
-            except Exception:
-                pass
+        dev = _get_device_by_identifier(device_registry, domain, speaker.device_id)
+        if dev and getattr(dev, "area_id", None):
+            return dev.area_id
 
     # 2. Check connection by MAC address
-    if speaker.mac_address and hasattr(device_registry, "async_get_device"):
+    if speaker.mac_address:
         norm_mac = speaker.mac_address.lower()
         for offset in range(-3, 4):
             alt_mac = mac_math_offset(norm_mac, offset) or norm_mac
             for test_mac in (alt_mac.lower(), alt_mac.upper()):
-                try:
-                    dev = device_registry.async_get_device(
-                        connections={(dr.CONNECTION_NETWORK_MAC, test_mac)}
-                    )
-                    if dev and getattr(dev, "area_id", None):
-                        return dev.area_id
-                except Exception:
-                    pass
+                dev = _get_device_by_connection(device_registry, dr.CONNECTION_NETWORK_MAC, test_mac)
+                if dev and getattr(dev, "area_id", None):
+                    return dev.area_id
 
     # 3. Check by friendly name
     devices = getattr(device_registry, "devices", None)
@@ -386,9 +422,9 @@ def _resolve_speaker_area(
         try:
             entries = devices.values() if hasattr(devices, "values") else devices
             target_name = speaker.name.strip().lower()
-            for dev in entries:
-                name = getattr(dev, "name", None) or getattr(dev, "name_by_user", None)
-                area_id = getattr(dev, "area_id", None)
+            for d in entries:
+                name = getattr(d, "name", None) or getattr(d, "name_by_user", None)
+                area_id = getattr(d, "area_id", None)
                 if name and area_id and name.strip().lower() == target_name:
                     return area_id
         except Exception:
@@ -403,7 +439,7 @@ def _sync_bluetooth_scanner_area(
     area_id: str | None,
 ) -> None:
     """Ensure the Bluetooth scanner device entry has the same area as the proxy speaker."""
-    if not device_registry or not area_id or not hasattr(device_registry, "async_get_device"):
+    if not device_registry or not area_id:
         return
     try:
         bt_dev = None
@@ -411,9 +447,7 @@ def _sync_bluetooth_scanner_area(
         for offset in range(-3, 4):
             alt = mac_math_offset(norm, offset) or norm
             for candidate in (alt.upper(), alt.lower()):
-                bt_dev = device_registry.async_get_device(
-                    connections={(dr.CONNECTION_BLUETOOTH, candidate)}
-                )
+                bt_dev = _get_device_by_connection(device_registry, dr.CONNECTION_BLUETOOTH, candidate)
                 if bt_dev:
                     break
             if bt_dev:
@@ -598,8 +632,8 @@ async def _speaker_scan_loop(
 
         # Check and synchronize area assignments dynamically
         device_reg = dr.async_get(hass)
-        if device_reg and hasattr(device_reg, "async_get_device"):
-            current_dev = device_reg.async_get_device(identifiers={(DOMAIN, speaker.device_id)})
+        if device_reg:
+            current_dev = _get_device_by_identifier(device_reg, DOMAIN, speaker.device_id)
             current_area = getattr(current_dev, "area_id", None) if current_dev else None
             if not current_area:
                 current_area = _resolve_speaker_area(device_reg, speaker)
@@ -707,6 +741,16 @@ async def _speaker_scan_loop(
                 await coordinator.async_refresh_token(speaker)
                 await asyncio.sleep(2.0)
                 continue
+            except SpeakerUnsupportedError as err:
+                _LOGGER.warning(
+                    "Device %s does not support Bluetooth scanning (HTTP 404); stopping scan worker: %s",
+                    speaker.name,
+                    err,
+                )
+                state.status = "unsupported"
+                state.notify_callbacks()
+                speaker.available = False
+                return
             except SpeakerConnectionError as err:
                 _LOGGER.debug(
                     "Connection issue with %s: %s (backing off %0.1fs)",
@@ -716,6 +760,13 @@ async def _speaker_scan_loop(
                 )
                 state.status = "unavailable"
                 state.notify_callbacks()
+                if not is_valid_ipv4(speaker.ip_address):
+                    _LOGGER.info(
+                        "Speaker %s has non-IPv4 address (%s); attempting token and IP refresh...",
+                        speaker.name,
+                        speaker.ip_address,
+                    )
+                    await coordinator.async_refresh_token(speaker)
                 await asyncio.sleep(backoff)
                 backoff = min(backoff * 2.0, 60.0)
                 continue

--- a/custom_components/google_home_bt_proxy/__init__.py
+++ b/custom_components/google_home_bt_proxy/__init__.py
@@ -143,7 +143,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 if alt := mac_math_offset(norm, offset):
                     all_speaker_macs.add(alt.upper())
 
-    is_bermuda_loaded = "bermuda" in getattr(hass.config, "components", set())
+    is_bermuda_loaded = "bermuda" in getattr(hass.config, "components", set()) or bool(
+        getattr(hass, "config_entries", None) and hass.config_entries.async_entries("bermuda")
+    )
     default_bermuda = is_bermuda_loaded or DEFAULT_BERMUDA_MODE
 
     for index, speaker in enumerate(active_speakers):
@@ -496,7 +498,9 @@ async def _speaker_scan_loop(
         speaker_rssi_offset = _get_speaker_setting(
             entry, speaker.device_id, CONF_RSSI_OFFSET, DEFAULT_RSSI_OFFSET
         )
-        is_bermuda_loaded = "bermuda" in getattr(hass.config, "components", set())
+        is_bermuda_loaded = "bermuda" in getattr(hass.config, "components", set()) or bool(
+            getattr(hass, "config_entries", None) and hass.config_entries.async_entries("bermuda")
+        )
         default_bermuda = is_bermuda_loaded or DEFAULT_BERMUDA_MODE
         speaker_bermuda_mode = bool(
             _get_speaker_setting(entry, speaker.device_id, CONF_BERMUDA_MODE, default_bermuda)

--- a/custom_components/google_home_bt_proxy/__init__.py
+++ b/custom_components/google_home_bt_proxy/__init__.py
@@ -345,7 +345,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 def _get_device_by_identifier(device_registry: Any, domain: str, identifier: str) -> Any:
     """Retrieve device by identifier supporting both modern and legacy HA APIs."""
-    # If device_registry is a test mock that didn't explicitly configure async_get_device_by_identifier
+    # If device_registry is a test mock without async_get_device_by_identifier
     if type(device_registry).__name__ in ("MagicMock", "Mock", "AsyncMock"):
         if hasattr(device_registry, "async_get_device"):
             try:
@@ -365,13 +365,17 @@ def _get_device_by_identifier(device_registry: Any, domain: str, identifier: str
     return None
 
 
-def _get_device_by_connection(device_registry: Any, connection_type: str, connection_val: str) -> Any:
+def _get_device_by_connection(
+    device_registry: Any, connection_type: str, connection_val: str
+) -> Any:
     """Retrieve device by connection supporting both modern and legacy HA APIs."""
-    # If device_registry is a test mock that didn't explicitly configure async_get_device_by_connection
+    # If device_registry is a test mock without async_get_device_by_connection
     if type(device_registry).__name__ in ("MagicMock", "Mock", "AsyncMock"):
         if hasattr(device_registry, "async_get_device"):
             try:
-                return device_registry.async_get_device(connections={(connection_type, connection_val)})
+                return device_registry.async_get_device(
+                    connections={(connection_type, connection_val)}
+                )
             except Exception:
                 pass
     if hasattr(device_registry, "async_get_device_by_connection"):
@@ -412,7 +416,9 @@ def _resolve_speaker_area(
         for offset in range(-3, 4):
             alt_mac = mac_math_offset(norm_mac, offset) or norm_mac
             for test_mac in (alt_mac.lower(), alt_mac.upper()):
-                dev = _get_device_by_connection(device_registry, dr.CONNECTION_NETWORK_MAC, test_mac)
+                dev = _get_device_by_connection(
+                    device_registry, dr.CONNECTION_NETWORK_MAC, test_mac
+                )
                 if dev and getattr(dev, "area_id", None):
                     return dev.area_id
 
@@ -447,7 +453,9 @@ def _sync_bluetooth_scanner_area(
         for offset in range(-3, 4):
             alt = mac_math_offset(norm, offset) or norm
             for candidate in (alt.upper(), alt.lower()):
-                bt_dev = _get_device_by_connection(device_registry, dr.CONNECTION_BLUETOOTH, candidate)
+                bt_dev = _get_device_by_connection(
+                    device_registry, dr.CONNECTION_BLUETOOTH, candidate
+                )
                 if bt_dev:
                     break
             if bt_dev:
@@ -743,7 +751,7 @@ async def _speaker_scan_loop(
                 continue
             except SpeakerUnsupportedError as err:
                 _LOGGER.warning(
-                    "Device %s does not support Bluetooth scanning (HTTP 404); stopping scan worker: %s",
+                    "Device %s unsupported for scanning (HTTP 404); stopping worker: %s",
                     speaker.name,
                     err,
                 )

--- a/custom_components/google_home_bt_proxy/api.py
+++ b/custom_components/google_home_bt_proxy/api.py
@@ -52,7 +52,11 @@ class GoogleHomeApiClient:
 
     def _build_url(self, ip_address: str, endpoint: str) -> str:
         protocol = "https" if self._use_ssl else "http"
-        host = f"[{ip_address}]" if ":" in ip_address and not ip_address.startswith("[") else ip_address
+        host = (
+            f"[{ip_address}]"
+            if ":" in ip_address and not ip_address.startswith("[")
+            else ip_address
+        )
         return f"{protocol}://{host}:{self._port}/{endpoint}"
 
     def _headers(self, auth_token: str) -> dict[str, str]:
@@ -189,7 +193,11 @@ class GoogleHomeApiClient:
             if (mac := data.get(key)) and is_valid_mac(str(mac)):
                 return str(mac)
         dev_info = data.get("device_info")
-        if isinstance(dev_info, dict) and (mac := dev_info.get("mac_address")) and is_valid_mac(str(mac)):
+        if (
+            isinstance(dev_info, dict)
+            and (mac := dev_info.get("mac_address"))
+            and is_valid_mac(str(mac))
+        ):
             return str(mac)
         net_info = data.get("net")
         if isinstance(net_info, dict):
@@ -200,7 +208,11 @@ class GoogleHomeApiClient:
             if isinstance(eth, dict) and (mac := eth.get("mac")) and is_valid_mac(str(mac)):
                 return str(mac)
         wifi_info = data.get("wifi")
-        if isinstance(wifi_info, dict) and (mac := wifi_info.get("wlan0_mac")) and is_valid_mac(str(mac)):
+        if (
+            isinstance(wifi_info, dict)
+            and (mac := wifi_info.get("wlan0_mac"))
+            and is_valid_mac(str(mac))
+        ):
             return str(mac)
         return None
 

--- a/custom_components/google_home_bt_proxy/api.py
+++ b/custom_components/google_home_bt_proxy/api.py
@@ -17,7 +17,7 @@ from .const import (
     HEADER_LOCAL_AUTH,
     PORT_HTTPS,
 )
-from .models import DiscoveredDevice, SpeakerNode, format_or_derive_mac
+from .models import DiscoveredDevice, SpeakerNode, format_or_derive_mac, is_valid_mac
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -28,6 +28,10 @@ class TokenExpiredError(Exception):
 
 class SpeakerConnectionError(Exception):
     """Raised on connection timeout or network failure."""
+
+
+class SpeakerUnsupportedError(Exception):
+    """Raised when the device returns HTTP 404 (Bluetooth scan API not implemented)."""
 
 
 class GoogleHomeApiClient:
@@ -48,7 +52,8 @@ class GoogleHomeApiClient:
 
     def _build_url(self, ip_address: str, endpoint: str) -> str:
         protocol = "https" if self._use_ssl else "http"
-        return f"{protocol}://{ip_address}:{self._port}/{endpoint}"
+        host = f"[{ip_address}]" if ":" in ip_address and not ip_address.startswith("[") else ip_address
+        return f"{protocol}://{host}:{self._port}/{endpoint}"
 
     def _headers(self, auth_token: str) -> dict[str, str]:
         return {
@@ -75,6 +80,11 @@ class GoogleHomeApiClient:
             ) as resp:
                 if resp.status == 401:
                     raise TokenExpiredError(f"Token expired on speaker {speaker.name}")
+                if resp.status == 404:
+                    speaker.available = False
+                    raise SpeakerUnsupportedError(
+                        f"Bluetooth scan API not supported on {speaker.name} (HTTP 404)"
+                    )
                 if resp.status == 200:
                     speaker.available = True
                     return True
@@ -97,6 +107,11 @@ class GoogleHomeApiClient:
             ) as resp:
                 if resp.status == 401:
                     raise TokenExpiredError(f"Token expired on speaker {speaker.name}")
+                if resp.status == 404:
+                    speaker.available = False
+                    raise SpeakerUnsupportedError(
+                        f"Bluetooth scan results API not supported on {speaker.name} (HTTP 404)"
+                    )
                 if resp.status == 200:
                     speaker.available = True
                     data = await resp.json()
@@ -167,24 +182,25 @@ class GoogleHomeApiClient:
 
     @staticmethod
     def _extract_mac(data: dict[str, Any]) -> str | None:
-        """Extract MAC address from eureka_info payload if present."""
+        """Extract valid MAC address from eureka_info payload if present."""
         if not isinstance(data, dict):
             return None
-        if mac := data.get("mac_address"):
-            return str(mac)
+        for key in ("mac_address", "hotspot_bssid"):
+            if (mac := data.get(key)) and is_valid_mac(str(mac)):
+                return str(mac)
         dev_info = data.get("device_info")
-        if isinstance(dev_info, dict) and (mac := dev_info.get("mac_address")):
+        if isinstance(dev_info, dict) and (mac := dev_info.get("mac_address")) and is_valid_mac(str(mac)):
             return str(mac)
         net_info = data.get("net")
         if isinstance(net_info, dict):
             wlan0 = net_info.get("wlan0")
-            if isinstance(wlan0, dict) and (mac := wlan0.get("mac")):
+            if isinstance(wlan0, dict) and (mac := wlan0.get("mac")) and is_valid_mac(str(mac)):
                 return str(mac)
             eth = net_info.get("ethernet")
-            if isinstance(eth, dict) and (mac := eth.get("mac")):
+            if isinstance(eth, dict) and (mac := eth.get("mac")) and is_valid_mac(str(mac)):
                 return str(mac)
         wifi_info = data.get("wifi")
-        if isinstance(wifi_info, dict) and (mac := wifi_info.get("wlan0_mac")):
+        if isinstance(wifi_info, dict) and (mac := wifi_info.get("wlan0_mac")) and is_valid_mac(str(mac)):
             return str(mac)
         return None
 

--- a/custom_components/google_home_bt_proxy/config_flow.py
+++ b/custom_components/google_home_bt_proxy/config_flow.py
@@ -354,12 +354,9 @@ class GoogleHomeBtProxyOptionsFlowHandler(config_entries.OptionsFlow):
             return DEFAULT_BERMUDA_MODE
         config = getattr(self.hass, "config", None)
         components = getattr(config, "components", set()) if config else set()
-        is_bermuda = (
-            "bermuda" in components
-            or bool(
-                getattr(self.hass, "config_entries", None)
-                and self.hass.config_entries.async_entries("bermuda")
-            )
+        is_bermuda = "bermuda" in components or bool(
+            getattr(self.hass, "config_entries", None)
+            and self.hass.config_entries.async_entries("bermuda")
         )
         return is_bermuda or DEFAULT_BERMUDA_MODE
 

--- a/custom_components/google_home_bt_proxy/config_flow.py
+++ b/custom_components/google_home_bt_proxy/config_flow.py
@@ -348,14 +348,30 @@ class GoogleHomeBtProxyOptionsFlowHandler(config_entries.OptionsFlow):
                 choices[spk_id] = spk_id
         return choices
 
+    def _get_default_bermuda(self) -> bool:
+        """Check if Bermuda is loaded or configured."""
+        if not getattr(self, "hass", None):
+            return DEFAULT_BERMUDA_MODE
+        config = getattr(self.hass, "config", None)
+        components = getattr(config, "components", set()) if config else set()
+        is_bermuda = (
+            "bermuda" in components
+            or bool(
+                getattr(self.hass, "config_entries", None)
+                and self.hass.config_entries.async_entries("bermuda")
+            )
+        )
+        return is_bermuda or DEFAULT_BERMUDA_MODE
+
     def _is_bermuda_mode_active(self) -> bool:
         """Check whether Bermuda Mode is active in options or for the selected speaker."""
         options = self.config_entry.options
+        default_bermuda = self._get_default_bermuda()
         if hasattr(self, "_selected_speaker") and self._selected_speaker != GLOBAL_SETTINGS:
             spk_overrides = options.get(CONF_SPEAKER_OVERRIDES, {}).get(self._selected_speaker, {})
             if CONF_BERMUDA_MODE in spk_overrides:
                 return bool(spk_overrides[CONF_BERMUDA_MODE])
-        return bool(options.get(CONF_BERMUDA_MODE, DEFAULT_BERMUDA_MODE))
+        return bool(options.get(CONF_BERMUDA_MODE, default_bermuda))
 
     async def async_step_init(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
         """Manage the options hub menu."""
@@ -381,11 +397,12 @@ class GoogleHomeBtProxyOptionsFlowHandler(config_entries.OptionsFlow):
             return self.async_create_entry(title="", data=new_options)
 
         options = self.config_entry.options
+        default_bermuda = options.get(CONF_BERMUDA_MODE, self._get_default_bermuda())
         schema = vol.Schema(
             {
                 vol.Optional(
                     CONF_BERMUDA_MODE,
-                    default=options.get(CONF_BERMUDA_MODE, DEFAULT_BERMUDA_MODE),
+                    default=default_bermuda,
                 ): bool,
                 vol.Optional(
                     CONF_FILTER_PEER_PROXIES,
@@ -592,6 +609,7 @@ class GoogleHomeBtProxyOptionsFlowHandler(config_entries.OptionsFlow):
             return self.async_create_entry(title="", data=new_options)
 
         has_custom = bool(existing_overrides)
+        default_bermuda = options.get(CONF_BERMUDA_MODE, self._get_default_bermuda())
         speaker_schema = vol.Schema(
             {
                 vol.Optional(
@@ -602,7 +620,7 @@ class GoogleHomeBtProxyOptionsFlowHandler(config_entries.OptionsFlow):
                     CONF_BERMUDA_MODE,
                     default=existing_overrides.get(
                         CONF_BERMUDA_MODE,
-                        options.get(CONF_BERMUDA_MODE, DEFAULT_BERMUDA_MODE),
+                        default_bermuda,
                     ),
                 ): bool,
                 vol.Optional(

--- a/custom_components/google_home_bt_proxy/coordinator.py
+++ b/custom_components/google_home_bt_proxy/coordinator.py
@@ -2,18 +2,91 @@
 
 from __future__ import annotations
 
+import ipaddress
 import logging
+import time
 from typing import TYPE_CHECKING
 
 from glocaltokens.client import GLocalAuthenticationTokens
+from zeroconf import ServiceBrowser, Zeroconf
 
 from .models import SpeakerNode
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
-    from zeroconf import Zeroconf
 
 _LOGGER = logging.getLogger(__name__)
+
+
+EXCLUDED_HARDWARE_KEYWORDS: tuple[str, ...] = (
+    "shield",
+    "smart tv",
+    "android tv",
+    "oled",
+    "chromecast",
+    "receiver",
+    "soundbar",
+    "tx-nr",
+    "group",
+    "matterhub",
+)
+
+
+def is_valid_ipv4(address: str) -> bool:
+    """Check if the string is a valid IPv4 address."""
+    try:
+        return isinstance(ipaddress.ip_address(address), ipaddress.IPv4Address)
+    except ValueError:
+        return False
+
+
+def resolve_cast_ipv4_map(
+    zc: Zeroconf | None = None, timeout: float = 3.5
+) -> tuple[dict[str, str], dict[str, str]]:
+    """Discover IPv4 addresses for Cast devices using Zeroconf."""
+    ipv4_by_id: dict[str, str] = {}
+    ipv4_by_name: dict[str, str] = {}
+
+    class _CastIPv4Listener:
+        def add_service(self, zc_instance: Zeroconf, type_: str, name: str) -> None:
+            try:
+                info = zc_instance.get_service_info(type_, name, 2000)
+                if not info:
+                    return
+                ipv4_addrs = [a for a in info.parsed_addresses() if is_valid_ipv4(a)]
+                if not ipv4_addrs:
+                    return
+                ipv4 = ipv4_addrs[0]
+                fn = info.properties.get(b"fn", b"").decode("utf-8", "ignore")
+                uid = info.properties.get(b"id", b"").decode("utf-8", "ignore")
+                if fn:
+                    ipv4_by_name[fn.strip().lower()] = ipv4
+                if uid:
+                    ipv4_by_id[uid.strip().lower()] = ipv4
+            except Exception:
+                pass
+
+        def update_service(self, zc_instance: Zeroconf, type_: str, name: str) -> None:
+            self.add_service(zc_instance, type_, name)
+
+        def remove_service(self, zc_instance: Zeroconf, type_: str, name: str) -> None:
+            pass
+
+    should_close = False
+    try:
+        zc_raw = zc
+        if zc_raw is None or type(zc_raw).__name__ == "HaZeroconf":
+            zc_raw = Zeroconf()
+            should_close = True
+        browser = ServiceBrowser(zc_raw, "_googlecast._tcp.local.", _CastIPv4Listener())
+        time.sleep(timeout)
+        browser.cancel()
+        if should_close:
+            zc_raw.close()
+    except Exception as err:
+        _LOGGER.debug("Zeroconf IPv4 resolution encountered error: %s", err)
+
+    return ipv4_by_id, ipv4_by_name
 
 
 class GoogleHomeProxyCoordinator:
@@ -50,12 +123,20 @@ class GoogleHomeProxyCoordinator:
             return list(self.speakers.values())
 
         def _fetch_devices():
-            return self._client.get_google_devices(
+            ipv4_by_id, ipv4_by_name = resolve_cast_ipv4_map(self._zeroconf)
+            raw = self._client.get_google_devices(
                 zeroconf_instance=self._zeroconf,
                 force_homegraph_reload=force_reload,
             )
+            return raw, ipv4_by_id, ipv4_by_name
 
-        raw_devices = await self.hass.async_add_executor_job(_fetch_devices)
+        job_result = await self.hass.async_add_executor_job(_fetch_devices)
+        if isinstance(job_result, tuple) and len(job_result) == 3:
+            raw_devices, ipv4_by_id, ipv4_by_name = job_result
+        else:
+            raw_devices = job_result
+            ipv4_by_id, ipv4_by_name = {}, {}
+
         speakers: dict[str, SpeakerNode] = {}
 
         for dev in raw_devices:
@@ -66,10 +147,48 @@ class GoogleHomeProxyCoordinator:
                 )
                 continue
 
+            hardware = (getattr(dev, "hardware", "") or "").lower()
+            name = (getattr(dev, "device_name", "") or "").lower()
+            if any(kw in hardware or kw in name for kw in EXCLUDED_HARDWARE_KEYWORDS):
+                _LOGGER.info(
+                    "Skipping non-speaker Cast device '%s' (hardware: '%s')",
+                    getattr(dev, "device_name", dev),
+                    getattr(dev, "hardware", "Unknown"),
+                )
+                continue
+
+            ip_address = dev.ip_address
+            if not is_valid_ipv4(ip_address):
+                unique_id = getattr(getattr(dev, "network_device", None), "unique_id", "") or ""
+                target_name = (dev.device_name or "").strip().lower()
+                if unique_id and unique_id.lower() in ipv4_by_id:
+                    ip_address = ipv4_by_id[unique_id.lower()]
+                    _LOGGER.info(
+                        "Resolved IPv4 address %s for %s via Cast ID %s (overriding %s)",
+                        ip_address,
+                        dev.device_name,
+                        unique_id,
+                        dev.ip_address,
+                    )
+                elif target_name in ipv4_by_name:
+                    ip_address = ipv4_by_name[target_name]
+                    _LOGGER.info(
+                        "Resolved IPv4 address %s for %s via Cast name (overriding %s)",
+                        ip_address,
+                        dev.device_name,
+                        dev.ip_address,
+                    )
+                else:
+                    _LOGGER.warning(
+                        "Could not resolve IPv4 for %s; retaining address %s",
+                        dev.device_name,
+                        dev.ip_address,
+                    )
+
             node = SpeakerNode(
                 device_id=dev.device_id,
                 name=dev.device_name,
-                ip_address=dev.ip_address,
+                ip_address=ip_address,
                 auth_token=dev.local_auth_token,
                 hardware=getattr(dev, "hardware", "Google Home"),
             )
@@ -86,5 +205,6 @@ class GoogleHomeProxyCoordinator:
         for spk in speakers:
             if spk.device_id == speaker.device_id:
                 speaker.auth_token = spk.auth_token
+                speaker.ip_address = spk.ip_address
                 return spk.auth_token
         return None

--- a/custom_components/google_home_bt_proxy/manifest.json
+++ b/custom_components/google_home_bt_proxy/manifest.json
@@ -13,5 +13,5 @@
     "pychromecast>=14.0.0"
   ],
   "dependencies": ["bluetooth", "zeroconf"],
-  "version": "1.3.0"
+  "version": "1.4.0"
 }

--- a/custom_components/google_home_bt_proxy/models.py
+++ b/custom_components/google_home_bt_proxy/models.py
@@ -8,11 +8,23 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 
 
+def is_valid_mac(mac: str | None) -> bool:
+    """Return True if mac is a valid, non-dummy 48-bit MAC address."""
+    if not mac or not isinstance(mac, str):
+        return False
+    cleaned = mac.replace(":", "").replace("-", "").replace(".", "").strip().upper()
+    return (
+        len(cleaned) == 12
+        and all(c in "0123456789ABCDEF" for c in cleaned)
+        and cleaned not in ("000000000000", "FFFFFFFFFFFF")
+    )
+
+
 def format_or_derive_mac(device_id: str, raw_mac: str | None = None) -> str:
     """Return a normalized MAC address (XX:XX:XX:XX:XX:XX) or derive a deterministic unicast MAC."""
     target = raw_mac or device_id
-    cleaned = target.replace(":", "").replace("-", "").replace(".", "").strip().upper()
-    if len(cleaned) == 12 and all(c in "0123456789ABCDEF" for c in cleaned):
+    if target and is_valid_mac(target):
+        cleaned = target.replace(":", "").replace("-", "").replace(".", "").strip().upper()
         return ":".join(cleaned[i : i + 2] for i in range(0, 12, 2))
 
     # Hash device_id to get deterministic bytes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ha-google-home-bt-proxy"
-version = "1.3.0"
+version = "1.4.0"
 description = "Home Assistant Google Home Bluetooth Proxy for Bermuda BLE Tracking"
 authors = [{name = "Steven T. Pelech"}]
 license = {text = "MIT"}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -9,6 +9,7 @@ from aiohttp import web
 from custom_components.google_home_bt_proxy.api import (
     GoogleHomeApiClient,
     SpeakerConnectionError,
+    SpeakerUnsupportedError,
     TokenExpiredError,
 )
 from custom_components.google_home_bt_proxy.models import SpeakerNode
@@ -292,3 +293,35 @@ async def test_get_bluetooth_status(aiohttp_client) -> None:
     assert "connected_devices" in status
     assert len(status["connected_devices"]) == 1
     assert status["connected_devices"][0]["name"] == "Phone"
+
+
+@pytest.mark.asyncio
+async def test_start_scan_and_get_results_unsupported_404(aiohttp_client) -> None:
+    """Verify start_scan and get_scan_results raise SpeakerUnsupportedError on HTTP 404."""
+
+    async def handle_404(request: web.Request) -> web.Response:
+        return web.Response(status=404)
+
+    app = web.Application()
+    app.router.add_post("/setup/bluetooth/scan", handle_404)
+    app.router.add_get("/setup/bluetooth/scan_results", handle_404)
+
+    client = await aiohttp_client(app)
+    api_client = GoogleHomeApiClient(client.session, port=client.server.port, use_ssl=False)
+
+    speaker = SpeakerNode(
+        device_id="test-spk",
+        name="Test Shield TV",
+        ip_address=str(client.server.host),
+        auth_token="test-token",
+    )
+
+    with pytest.raises(SpeakerUnsupportedError):
+        await api_client.start_scan(speaker)
+    assert speaker.available is False
+
+    speaker.available = True
+    with pytest.raises(SpeakerUnsupportedError):
+        await api_client.get_scan_results(speaker)
+    assert speaker.available is False
+

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -324,4 +324,3 @@ async def test_start_scan_and_get_results_unsupported_404(aiohttp_client) -> Non
     with pytest.raises(SpeakerUnsupportedError):
         await api_client.get_scan_results(speaker)
     assert speaker.available is False
-

--- a/tests/test_bermuda_compatibility.py
+++ b/tests/test_bermuda_compatibility.py
@@ -137,6 +137,17 @@ def test_eureka_mac_extraction():
         GoogleHomeApiClient._extract_mac({"wifi": {"wlan0_mac": "6C:AD:F8:11:22:77"}})
         == "6C:AD:F8:11:22:77"
     )
+    # hotspot_bssid fallback when mac_address is 00:00:00:00:00:00
+    assert (
+        GoogleHomeApiClient._extract_mac(
+            {"mac_address": "00:00:00:00:00:00", "hotspot_bssid": "FA:8F:CA:69:B6:3E"}
+        )
+        == "FA:8F:CA:69:B6:3E"
+    )
+    # Dummy MAC rejection
+    assert GoogleHomeApiClient._extract_mac({"mac_address": "00:00:00:00:00:00"}) is None
+    assert GoogleHomeApiClient._extract_mac({"mac_address": "FF:FF:FF:FF:FF:FF"}) is None
+
     # Empty / none
     assert GoogleHomeApiClient._extract_mac({}) is None
     assert GoogleHomeApiClient._extract_mac("not_a_dict") is None

--- a/tests/test_bermuda_compatibility.py
+++ b/tests/test_bermuda_compatibility.py
@@ -779,3 +779,36 @@ async def test_speaker_scan_loop_dynamic_area_sync():
 
     # Verify bluetooth scanner device was updated with the new area
     mock_devreg.async_update_device.assert_called_with("bt_dev_id", area_id="master_bedroom")
+
+
+@pytest.mark.asyncio
+async def test_options_flow_bermuda_mode_default_with_config_entries():
+    """Verify Options Flow defaults Bermuda mode to True when Bermuda is in config_entries."""
+    from custom_components.google_home_bt_proxy.config_flow import (
+        GoogleHomeBtProxyOptionsFlowHandler,
+    )
+
+    mock_entry = MagicMock()
+    mock_entry.entry_id = "test-entry-bermuda-ce"
+    mock_entry.options = {}
+
+    handler = GoogleHomeBtProxyOptionsFlowHandler(mock_entry)
+    mock_hass = MagicMock()
+    mock_hass.config.components = set()  # Bermuda NOT in components yet (e.g. startup)
+    mock_hass.config_entries.async_entries.side_effect = lambda domain: [MagicMock()] if domain == "bermuda" else []
+    handler.hass = mock_hass
+
+    assert handler._get_default_bermuda() is True
+    assert handler._is_bermuda_mode_active() is True
+
+    res = await handler.async_step_scanning(None)
+    assert res["type"] == "form"
+    # Verify default in schema is True
+    bermuda_field = None
+    for k in res["data_schema"].schema:
+        if k == CONF_BERMUDA_MODE:
+            bermuda_field = k
+            break
+    assert bermuda_field is not None
+    assert bermuda_field.default() is True
+

--- a/tests/test_bermuda_compatibility.py
+++ b/tests/test_bermuda_compatibility.py
@@ -806,7 +806,9 @@ async def test_options_flow_bermuda_mode_default_with_config_entries():
     handler = GoogleHomeBtProxyOptionsFlowHandler(mock_entry)
     mock_hass = MagicMock()
     mock_hass.config.components = set()  # Bermuda NOT in components yet (e.g. startup)
-    mock_hass.config_entries.async_entries.side_effect = lambda domain: [MagicMock()] if domain == "bermuda" else []
+    mock_hass.config_entries.async_entries.side_effect = lambda domain: (
+        [MagicMock()] if domain == "bermuda" else []
+    )
     handler.hass = mock_hass
 
     assert handler._get_default_bermuda() is True
@@ -822,4 +824,3 @@ async def test_options_flow_bermuda_mode_default_with_config_entries():
             break
     assert bermuda_field is not None
     assert bermuda_field.default() is True
-

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -181,3 +181,65 @@ async def test_coordinator_fetch_devices_executor_invoked():
         zeroconf_instance=None,
         force_homegraph_reload=True,
     )
+
+
+@pytest.mark.asyncio
+async def test_coordinator_skips_non_speaker_cast_hardware():
+    """Verify coordinator skips non-speaker Cast devices such as Android TVs, Shield, Chromecasts, and receivers."""
+    mock_hass = MagicMock()
+    mock_hass.async_add_executor_job = AsyncMock()
+
+    spk_real = MagicMock(
+        device_id="spk-real",
+        device_name="Living Room Speaker",
+        ip_address="192.168.1.50",
+        local_auth_token="token-real",
+        hardware="Google Nest Mini",
+    )
+    dev_shield = MagicMock(
+        device_id="shield-1",
+        device_name="SHIELD",
+        ip_address="192.168.1.51",
+        local_auth_token="token-shield",
+        hardware="SHIELD Android TV",
+    )
+    dev_tv = MagicMock(
+        device_id="tv-1",
+        device_name="Family Room TV",
+        ip_address="192.168.1.52",
+        local_auth_token="token-tv",
+        hardware="Smart TV Pro",
+    )
+    dev_chromecast = MagicMock(
+        device_id="cc-1",
+        device_name="Gym TV",
+        ip_address="192.168.1.53",
+        local_auth_token="token-cc",
+        hardware="Chromecast Ultra",
+    )
+    dev_onkyo = MagicMock(
+        device_id="onkyo-1",
+        device_name="Onkyo Receiver",
+        ip_address="192.168.1.54",
+        local_auth_token="token-onkyo",
+        hardware="Onkyo TX-NR676",
+    )
+
+    mock_hass.async_add_executor_job.return_value = [
+        spk_real,
+        dev_shield,
+        dev_tv,
+        dev_chromecast,
+        dev_onkyo,
+    ]
+
+    coordinator = GoogleHomeProxyCoordinator(
+        hass=mock_hass,
+        master_token="test-master-token",
+    )
+
+    speakers = await coordinator.async_get_speakers()
+    assert len(speakers) == 1
+    assert speakers[0].device_id == "spk-real"
+    assert speakers[0].name == "Living Room Speaker"
+

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -185,7 +185,7 @@ async def test_coordinator_fetch_devices_executor_invoked():
 
 @pytest.mark.asyncio
 async def test_coordinator_skips_non_speaker_cast_hardware():
-    """Verify coordinator skips non-speaker Cast devices such as Android TVs, Shield, Chromecasts, and receivers."""
+    """Verify coordinator skips non-speaker Cast hardware (TVs, Shield, AVRs)."""
     mock_hass = MagicMock()
     mock_hass.async_add_executor_job = AsyncMock()
 
@@ -242,4 +242,3 @@ async def test_coordinator_skips_non_speaker_cast_hardware():
     assert len(speakers) == 1
     assert speakers[0].device_id == "spk-real"
     assert speakers[0].name == "Living Room Speaker"
-

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -193,7 +193,7 @@ async def test_speaker_scan_loop_normal_cycle():
     )
 
     # Let the loop perform one scan cycle
-    await asyncio.sleep(0.05)
+    await asyncio.sleep(0.2)
     loop_task.cancel()
 
     with pytest.raises(asyncio.CancelledError):

--- a/uv.lock
+++ b/uv.lock
@@ -1376,7 +1376,7 @@ wheels = [
 
 [[package]]
 name = "ha-google-home-bt-proxy"
-version = "1.3.0"
+version = "1.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "bluetooth-data-tools" },


### PR DESCRIPTION
### Summary
- Detects Bermuda presence not only from `hass.config.components` but also `hass.config_entries.async_entries('bermuda')`. During startup phase 2, integrations initialize concurrently; Bermuda's entry exists in config entries before its setup finishes.
- Updates options flow to dynamically default `CONF_BERMUDA_MODE` to `True` if Bermuda is detected in Home Assistant and no explicit override exists.
- Adds comprehensive unit tests covering config entries fallback and options flow defaults.