### PR TITLE
Fix master token authentication when Google password is not stored

### DIFF
--- a/custom_components/google_home_bt_proxy/coordinator.py
+++ b/custom_components/google_home_bt_proxy/coordinator.py
@@ -110,7 +110,7 @@ class GoogleHomeProxyCoordinator:
         self._zeroconf = zeroconf_instance
         self._client = GLocalAuthenticationTokens(
             username=username,
-            password=password,
+            password=password or "",
             master_token=master_token,
             android_id=android_id,
             verbose=False,


### PR DESCRIPTION
fix(auth): allow master token authentication without a stored password

glocaltokens currently rejects authentication when `password` is None, even when a valid `aas_et/...` master token is already available.

Since the integration no longer stores the Google account password, the coordinator passes `None` to GLocalAuthenticationTokens, causing:

"Username and password are not set."

Normalize the missing password to an empty string before initializing GLocalAuthenticationTokens. This allows glocaltokens to reuse the existing master token without attempting a username/password login.