### PR TITLE
fix: resilient 404 recovery, UI revival button, and zeroconf cache reuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.1] - 2026-09-09
+
+### Added
+- **UI Speaker Revival (`Revive Speaker` Button & Scan Button Enhancement)**:
+  - Added dedicated `button.<speaker>_revive` ("Revive Speaker") entity to instantly reconnect, refresh auth token and IP, clear unsupported/unavailable states, and restart the scan worker from the Home Assistant UI.
+  - Enhanced existing `button.<speaker>_trigger_scan` ("Trigger Bluetooth Scan") to automatically revive an unsupported or unavailable speaker upon being pressed.
+- **Resilient 404 Recovery & Transient Error Tolerance**:
+  - Previously active speakers (`total_advertisements > 0`) are never permanently marked as unsupported on HTTP 404; errors during reboots or socket drops are treated as temporary connectivity glitches with exponential backoff.
+  - New speakers require 5 consecutive HTTP 404 failures before the worker pauses, preventing false-positive terminations during speaker bootup.
+  - Paused workers wait on UI revival event (`trigger_scan_event`) or periodic 30-minute retry without exiting the background task.
+
+### Fixed
+- **Duplicate Zeroconf Instance Deprecation Warning**:
+  - Reused Home Assistant's managed Zeroconf instance directly in `resolve_cast_ipv4_map` without instantiating a duplicate `Zeroconf()`, utilizing Home Assistant's warm mDNS cache and silencing the warning.
+- **Device Registry `.devices` Mapping Deprecation Warning**:
+  - Directly iterated `device_registry.devices` in `_resolve_speaker_area` without calling `.values()`, ensuring forward compatibility with Home Assistant 2027.9.0.
+
 ## [1.4.0] - 2026-09-08
 
 ### Added

--- a/custom_components/google_home_bt_proxy/__init__.py
+++ b/custom_components/google_home_bt_proxy/__init__.py
@@ -85,6 +85,8 @@ from .scanner import GoogleHomeRemoteScanner
 
 _LOGGER = logging.getLogger(__name__)
 
+MAX_CONSECUTIVE_UNSUPPORTED = 5
+
 PLATFORMS: list[Platform] = [
     Platform.SENSOR,
     Platform.SWITCH,
@@ -426,8 +428,8 @@ def _resolve_speaker_area(
     devices = getattr(device_registry, "devices", None)
     if devices is not None:
         try:
-            entries = devices.values() if hasattr(devices, "values") else devices
             target_name = speaker.name.strip().lower()
+            entries = devices.values() if isinstance(devices, dict) else devices
             for d in entries:
                 name = getattr(d, "name", None) or getattr(d, "name_by_user", None)
                 area_id = getattr(d, "area_id", None)
@@ -505,6 +507,7 @@ async def _speaker_scan_loop(
     _LOGGER.info("Starting Bluetooth scan worker loop for %s", speaker.name)
 
     backoff = 1.0
+    consecutive_unsupported = 0
     continuous_skip_start: float | None = None
     while True:
         if not state.enabled:
@@ -743,6 +746,7 @@ async def _speaker_scan_loop(
                 state.last_scan_timestamp = time.time()
                 state.status = "idle"
                 state.notify_callbacks()
+                consecutive_unsupported = 0
 
             except TokenExpiredError:
                 _LOGGER.warning("Auth token expired for %s, requesting refresh...", speaker.name)
@@ -750,15 +754,57 @@ async def _speaker_scan_loop(
                 await asyncio.sleep(2.0)
                 continue
             except SpeakerUnsupportedError as err:
+                consecutive_unsupported += 1
+                if (
+                    state.total_advertisements > 0
+                    or consecutive_unsupported < MAX_CONSECUTIVE_UNSUPPORTED
+                ):
+                    _LOGGER.warning(
+                        "Device %s returned HTTP 404 during scan (%d/%d); "
+                        "retrying with backoff %0.1fs: %s",
+                        speaker.name,
+                        consecutive_unsupported,
+                        MAX_CONSECUTIVE_UNSUPPORTED,
+                        backoff,
+                        err,
+                    )
+                    state.status = "unavailable"
+                    state.notify_callbacks()
+                    speaker.available = False
+                    await asyncio.sleep(backoff)
+                    backoff = min(backoff * 2.0, 60.0)
+                    continue
+
                 _LOGGER.warning(
-                    "Device %s unsupported for scanning (HTTP 404); stopping worker: %s",
+                    "Device %s unsupported for scanning (HTTP 404 after %d consecutive attempts); "
+                    "pausing worker: %s",
                     speaker.name,
+                    consecutive_unsupported,
                     err,
                 )
                 state.status = "unsupported"
                 state.notify_callbacks()
                 speaker.available = False
-                return
+
+                try:
+                    await asyncio.wait_for(state.trigger_scan_event.wait(), timeout=1800.0)
+                except TimeoutError:
+                    pass
+
+                state.trigger_scan_event.clear()
+                consecutive_unsupported = 0
+                backoff = 1.0
+                speaker.available = True
+                _LOGGER.info("Attempting to revive scan worker for %s...", speaker.name)
+                try:
+                    await coordinator.async_refresh_token(speaker)
+                except Exception as refresh_err:
+                    _LOGGER.debug(
+                        "Error refreshing token on revival for %s: %s",
+                        speaker.name,
+                        refresh_err,
+                    )
+                continue
             except SpeakerConnectionError as err:
                 _LOGGER.debug(
                     "Connection issue with %s: %s (backing off %0.1fs)",

--- a/custom_components/google_home_bt_proxy/button.py
+++ b/custom_components/google_home_bt_proxy/button.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from homeassistant.components.button import ButtonEntity
@@ -13,6 +14,8 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .const import DOMAIN
 from .models import SpeakerNode, SpeakerProxyState
 
+_LOGGER = logging.getLogger(__name__)
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -21,13 +24,15 @@ async def async_setup_entry(
 ) -> None:
     """Set up Google Home Bluetooth Proxy buttons from config entry."""
     entry_data = hass.data[DOMAIN][entry.entry_id]
+    coordinator = entry_data.get("coordinator")
     speakers_data: dict[str, dict[str, Any]] = entry_data.get("speakers", {})
     entities: list[ButtonEntity] = []
 
     for _speaker_id, data in speakers_data.items():
         speaker: SpeakerNode = data["speaker"]
         state: SpeakerProxyState = data["state"]
-        entities.append(GoogleHomeBtProxyScanButton(speaker, state))
+        entities.append(GoogleHomeBtProxyScanButton(speaker, state, coordinator=coordinator))
+        entities.append(GoogleHomeBtProxyReviveButton(speaker, state, coordinator=coordinator))
 
     async_add_entities(entities)
 
@@ -38,10 +43,16 @@ class GoogleHomeBtProxyScanButton(ButtonEntity):
     _attr_has_entity_name = True
     _attr_icon = "mdi:radar"
 
-    def __init__(self, speaker: SpeakerNode, state: SpeakerProxyState) -> None:
+    def __init__(
+        self,
+        speaker: SpeakerNode,
+        state: SpeakerProxyState,
+        coordinator: Any | None = None,
+    ) -> None:
         """Initialize scan button."""
         self._speaker = speaker
         self._state = state
+        self._coordinator = coordinator
         self._attr_name = "Trigger Bluetooth Scan"
         self._attr_unique_id = f"{speaker.device_id}_trigger_scan"
         self._attr_device_info = DeviceInfo(
@@ -54,4 +65,64 @@ class GoogleHomeBtProxyScanButton(ButtonEntity):
 
     async def async_press(self) -> None:
         """Handle button press by signaling scan event."""
+        if self._state.status in ("unsupported", "unavailable"):
+            self._speaker.available = True
+            self._state.status = "idle"
+            if self._coordinator is not None and hasattr(self._coordinator, "async_refresh_token"):
+                try:
+                    await self._coordinator.async_refresh_token(self._speaker)
+                except Exception as err:
+                    _LOGGER.debug(
+                        "Token refresh error during scan trigger for %s: %s",
+                        self._speaker.name,
+                        err,
+                    )
+            self._state.notify_callbacks()
+        self._state.trigger_scan_event.set()
+
+
+class GoogleHomeBtProxyReviveButton(ButtonEntity):
+    """Button to revive / reconnect an unavailable or unsupported speaker."""
+
+    _attr_has_entity_name = True
+    _attr_icon = "mdi:restart"
+
+    def __init__(
+        self,
+        speaker: SpeakerNode,
+        state: SpeakerProxyState,
+        coordinator: Any | None = None,
+    ) -> None:
+        """Initialize revive button."""
+        self._speaker = speaker
+        self._state = state
+        self._coordinator = coordinator
+        self._attr_name = "Revive Speaker"
+        self._attr_unique_id = f"{speaker.device_id}_revive"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, speaker.device_id)},
+            connections={(CONNECTION_NETWORK_MAC, speaker.mac_address.lower())},
+            name=speaker.name,
+            manufacturer="Google",
+            model=speaker.hardware,
+        )
+
+    async def async_press(self) -> None:
+        """Handle revive button press."""
+        _LOGGER.info(
+            "Revive button pressed for %s; resetting state and refreshing token...",
+            self._speaker.name,
+        )
+        self._speaker.available = True
+        self._state.status = "idle"
+        if self._coordinator is not None and hasattr(self._coordinator, "async_refresh_token"):
+            try:
+                await self._coordinator.async_refresh_token(self._speaker)
+            except Exception as err:
+                _LOGGER.debug(
+                    "Token refresh error during revival for %s: %s",
+                    self._speaker.name,
+                    err,
+                )
+        self._state.notify_callbacks()
         self._state.trigger_scan_event.set()

--- a/custom_components/google_home_bt_proxy/coordinator.py
+++ b/custom_components/google_home_bt_proxy/coordinator.py
@@ -75,7 +75,7 @@ def resolve_cast_ipv4_map(
     should_close = False
     try:
         zc_raw = zc
-        if zc_raw is None or type(zc_raw).__name__ == "HaZeroconf":
+        if zc_raw is None:
             zc_raw = Zeroconf()
             should_close = True
         browser = ServiceBrowser(zc_raw, "_googlecast._tcp.local.", _CastIPv4Listener())

--- a/custom_components/google_home_bt_proxy/manifest.json
+++ b/custom_components/google_home_bt_proxy/manifest.json
@@ -13,5 +13,5 @@
     "pychromecast>=14.0.0"
   ],
   "dependencies": ["bluetooth", "zeroconf"],
-  "version": "1.4.0"
+  "version": "1.4.1"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ha-google-home-bt-proxy"
-version = "1.4.0"
+version = "1.4.1"
 description = "Home Assistant Google Home Bluetooth Proxy for Bermuda BLE Tracking"
 authors = [{name = "Steven T. Pelech"}]
 license = {text = "MIT"}

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -1,10 +1,11 @@
 """Tests for Google Home Bluetooth Proxy button platform."""
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from custom_components.google_home_bt_proxy.button import (
+    GoogleHomeBtProxyReviveButton,
     GoogleHomeBtProxyScanButton,
     async_setup_entry,
 )
@@ -32,15 +33,17 @@ async def test_button_setup_entry(speaker_and_state):
     mock_entry = MagicMock()
     mock_entry.entry_id = "entry-btn-123"
 
+    mock_coordinator = MagicMock()
     mock_hass.data = {
         DOMAIN: {
             "entry-btn-123": {
+                "coordinator": mock_coordinator,
                 "speakers": {
                     speaker.device_id: {
                         "speaker": speaker,
                         "state": state,
                     }
-                }
+                },
             }
         }
     }
@@ -52,8 +55,9 @@ async def test_button_setup_entry(speaker_and_state):
 
     await async_setup_entry(mock_hass, mock_entry, mock_add_entities)
 
-    assert len(added_entities) == 1
+    assert len(added_entities) == 2
     assert isinstance(added_entities[0], GoogleHomeBtProxyScanButton)
+    assert isinstance(added_entities[1], GoogleHomeBtProxyReviveButton)
 
 
 @pytest.mark.asyncio
@@ -65,4 +69,60 @@ async def test_button_press(speaker_and_state):
     assert not state.trigger_scan_event.is_set()
 
     await button.async_press()
+    assert state.trigger_scan_event.is_set()
+
+
+@pytest.mark.asyncio
+async def test_scan_button_press_revives_unsupported_speaker(speaker_and_state):
+    speaker, state = speaker_and_state
+    speaker.available = False
+    state.status = "unsupported"
+
+    mock_coord = MagicMock()
+    mock_coord.async_refresh_token = AsyncMock()
+
+    button = GoogleHomeBtProxyScanButton(speaker, state, coordinator=mock_coord)
+    await button.async_press()
+
+    assert speaker.available is True
+    assert state.status == "idle"
+    assert state.trigger_scan_event.is_set()
+    mock_coord.async_refresh_token.assert_awaited_once_with(speaker)
+
+
+@pytest.mark.asyncio
+async def test_revive_button_press(speaker_and_state):
+    speaker, state = speaker_and_state
+    speaker.available = False
+    state.status = "unsupported"
+
+    mock_coord = MagicMock()
+    mock_coord.async_refresh_token = AsyncMock()
+
+    revive_btn = GoogleHomeBtProxyReviveButton(speaker, state, coordinator=mock_coord)
+    assert revive_btn.unique_id == "spk-btn-1_revive"
+    assert revive_btn.name == "Revive Speaker"
+
+    await revive_btn.async_press()
+
+    assert speaker.available is True
+    assert state.status == "idle"
+    assert state.trigger_scan_event.is_set()
+    mock_coord.async_refresh_token.assert_awaited_once_with(speaker)
+
+
+@pytest.mark.asyncio
+async def test_revive_button_press_error_handling(speaker_and_state):
+    speaker, state = speaker_and_state
+    speaker.available = False
+    state.status = "unavailable"
+
+    mock_coord = MagicMock()
+    mock_coord.async_refresh_token = AsyncMock(side_effect=RuntimeError("Token error"))
+
+    revive_btn = GoogleHomeBtProxyReviveButton(speaker, state, coordinator=mock_coord)
+    await revive_btn.async_press()
+
+    assert speaker.available is True
+    assert state.status == "idle"
     assert state.trigger_scan_event.is_set()

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -4,7 +4,10 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from custom_components.google_home_bt_proxy.coordinator import GoogleHomeProxyCoordinator
+from custom_components.google_home_bt_proxy.coordinator import (
+    GoogleHomeProxyCoordinator,
+    resolve_cast_ipv4_map,
+)
 from custom_components.google_home_bt_proxy.models import SpeakerNode
 
 
@@ -242,3 +245,52 @@ async def test_coordinator_skips_non_speaker_cast_hardware():
     assert len(speakers) == 1
     assert speakers[0].device_id == "spk-real"
     assert speakers[0].name == "Living Room Speaker"
+
+
+def test_resolve_cast_ipv4_map_reuses_hazeroconf():
+    """Verify resolve_cast_ipv4_map reuses HA zeroconf without instantiating a new Zeroconf."""
+    mock_ha_zc = MagicMock()
+    type(mock_ha_zc).__name__ = "HaZeroconf"
+    mock_ha_zc.close = MagicMock()
+
+    from unittest.mock import patch
+
+    with (
+        patch("custom_components.google_home_bt_proxy.coordinator.ServiceBrowser") as mock_browser,
+        patch("custom_components.google_home_bt_proxy.coordinator.Zeroconf") as mock_new_zc,
+        patch("time.sleep"),
+    ):
+        mock_browser_inst = MagicMock()
+        mock_browser.return_value = mock_browser_inst
+
+        ipv4_by_id, ipv4_by_name = resolve_cast_ipv4_map(mock_ha_zc, timeout=0.01)
+
+        # Should NOT instantiate a new Zeroconf
+        mock_new_zc.assert_not_called()
+        # Should NOT close the shared HaZeroconf
+        mock_ha_zc.close.assert_not_called()
+        # Should create browser with the shared instance
+        mock_browser.assert_called_once()
+        assert mock_browser.call_args[0][0] == mock_ha_zc
+        mock_browser_inst.cancel.assert_called_once()
+
+
+def test_resolve_cast_ipv4_map_fallback_when_none():
+    """Verify resolve_cast_ipv4_map creates and closes standalone Zeroconf when zc is None."""
+    from unittest.mock import patch
+
+    with (
+        patch("custom_components.google_home_bt_proxy.coordinator.ServiceBrowser") as mock_browser,
+        patch("custom_components.google_home_bt_proxy.coordinator.Zeroconf") as mock_new_zc,
+        patch("time.sleep"),
+    ):
+        mock_zc_inst = MagicMock()
+        mock_new_zc.return_value = mock_zc_inst
+        mock_browser_inst = MagicMock()
+        mock_browser.return_value = mock_browser_inst
+
+        ipv4_by_id, ipv4_by_name = resolve_cast_ipv4_map(None, timeout=0.01)
+
+        mock_new_zc.assert_called_once()
+        mock_zc_inst.close.assert_called_once()
+        mock_browser_inst.cancel.assert_called_once()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from custom_components.google_home_bt_proxy import (
+    _resolve_speaker_area,
     _speaker_scan_loop,
     async_setup,
     async_setup_entry,
@@ -13,6 +14,7 @@ from custom_components.google_home_bt_proxy import (
 )
 from custom_components.google_home_bt_proxy.api import (
     SpeakerConnectionError,
+    SpeakerUnsupportedError,
     TokenExpiredError,
 )
 from custom_components.google_home_bt_proxy.const import (
@@ -699,3 +701,149 @@ async def test_async_reload_entry():
         await async_reload_entry(mock_hass, mock_entry)
         mock_unload.assert_called_once_with(mock_hass, mock_entry)
         mock_setup.assert_called_once_with(mock_hass, mock_entry)
+
+
+@pytest.mark.asyncio
+async def test_speaker_scan_loop_unsupported_error_recovers_active_speaker():
+    """Verify an active speaker (total_advertisements > 0) treats 404 as transient."""
+    mock_hass = MagicMock()
+    mock_entry = MagicMock()
+    mock_entry.options = {}
+
+    mock_coord = MagicMock()
+    mock_api = MagicMock()
+    mock_api.start_scan = AsyncMock(
+        side_effect=[
+            SpeakerUnsupportedError("HTTP 404"),
+            True,
+            asyncio.CancelledError(),
+        ]
+    )
+    mock_api.get_scan_results = AsyncMock(return_value=[DiscoveredDevice("AA:BB:CC:DD:EE:FF", -60)])
+
+    mock_speaker = SpeakerNode(
+        device_id="spk-active",
+        name="Basement speaker",
+        ip_address="10.0.0.112",
+        auth_token="test-token",
+    )
+    mock_scanner = MagicMock()
+    mock_scanner.process_scan_results = MagicMock(return_value=1)
+    mock_detector = MagicMock()
+    mock_detector.async_is_playing = AsyncMock(return_value=False)
+
+    from custom_components.google_home_bt_proxy.models import SpeakerProxyState
+
+    state = SpeakerProxyState(enabled=True)
+    state.total_advertisements = 10  # previously active
+
+    with patch("asyncio.sleep", AsyncMock()):
+        with pytest.raises(asyncio.CancelledError):
+            await _speaker_scan_loop(
+                mock_hass,
+                mock_entry,
+                mock_coord,
+                mock_api,
+                mock_speaker,
+                mock_scanner,
+                initial_delay=0.0,
+                playback_detector=mock_detector,
+                state=state,
+            )
+
+    assert mock_api.start_scan.call_count == 3
+    assert state.status != "unsupported"
+
+
+@pytest.mark.asyncio
+async def test_speaker_scan_loop_unsupported_error_pauses_and_revives():
+    """Verify repeated 404s pause the worker and UI revival event restarts scanning."""
+    mock_hass = MagicMock()
+    mock_entry = MagicMock()
+    mock_entry.options = {}
+
+    mock_coord = MagicMock()
+    mock_coord.async_refresh_token = AsyncMock()
+
+    mock_api = MagicMock()
+    # 5 unsupported errors, then pause, then user triggers revival, then 1 success, then cancel
+    mock_api.start_scan = AsyncMock(
+        side_effect=[
+            SpeakerUnsupportedError("HTTP 404"),
+            SpeakerUnsupportedError("HTTP 404"),
+            SpeakerUnsupportedError("HTTP 404"),
+            SpeakerUnsupportedError("HTTP 404"),
+            SpeakerUnsupportedError("HTTP 404"),
+            True,
+            asyncio.CancelledError(),
+        ]
+    )
+    mock_api.get_scan_results = AsyncMock(return_value=[])
+
+    mock_speaker = SpeakerNode(
+        device_id="spk-new",
+        name="New Speaker",
+        ip_address="10.0.0.120",
+        auth_token="test-token",
+    )
+    mock_scanner = MagicMock()
+    mock_scanner.process_scan_results = MagicMock(return_value=0)
+    mock_detector = MagicMock()
+    mock_detector.async_is_playing = AsyncMock(return_value=False)
+
+    from custom_components.google_home_bt_proxy.models import SpeakerProxyState
+
+    state = SpeakerProxyState(enabled=True)
+
+    # When wait_for is called on the event, simulate UI button setting trigger_scan_event
+    async def mock_wait_for(fut, timeout=None):  # noqa: ASYNC109
+        state.trigger_scan_event.set()
+        return await fut
+
+    with (
+        patch("asyncio.sleep", AsyncMock()),
+        patch("asyncio.wait_for", side_effect=mock_wait_for),
+    ):
+        with pytest.raises(asyncio.CancelledError):
+            await _speaker_scan_loop(
+                mock_hass,
+                mock_entry,
+                mock_coord,
+                mock_api,
+                mock_speaker,
+                mock_scanner,
+                initial_delay=0.0,
+                playback_detector=mock_detector,
+                state=state,
+            )
+
+    mock_coord.async_refresh_token.assert_awaited_once_with(mock_speaker)
+    assert mock_speaker.available is True
+
+
+def test_resolve_speaker_area_devices_direct_iterable():
+    """Verify _resolve_speaker_area directly iterates device_registry.devices without .values()."""
+    mock_dr = MagicMock(spec=[])
+    mock_dev = MagicMock()
+    mock_dev.name = "Living Room Speaker"
+    mock_dev.name_by_user = None
+    mock_dev.area_id = "living_room_area"
+
+    class MockDevicesIterable:
+        """Iterable collection that has no .values() method."""
+
+        def __iter__(self):
+            return iter([mock_dev])
+
+    mock_dr.devices = MockDevicesIterable()
+
+    speaker = SpeakerNode(
+        device_id="spk-test",
+        name="Living Room Speaker",
+        ip_address="10.0.0.50",
+        auth_token="token",
+        mac_address=None,
+    )
+
+    area = _resolve_speaker_area(mock_dr, speaker)
+    assert area == "living_room_area"

--- a/uv.lock
+++ b/uv.lock
@@ -1376,7 +1376,7 @@ wheels = [
 
 [[package]]
 name = "ha-google-home-bt-proxy"
-version = "1.4.0"
+version = "1.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "bluetooth-data-tools" },


### PR DESCRIPTION
## Summary

This patch release addresses log warnings and resilience edge cases observed during long-running operation:

### 1. Resilient 404 Recovery & Error Tolerance
- **Transient Disconnect Protection**: Active speakers with `total_advertisements > 0` are never permanently marked `unsupported` on HTTP 404. Transient 404s following reboots, AP roams, or socket disconnects are treated as temporary connection failures and retried with exponential backoff.
- **Initial Bootup Resilience**: New speakers require 5 consecutive 404 failures before pausing the worker.
- **Persistent Workers**: When marked `unsupported`, the background worker pauses on `state.trigger_scan_event.wait(timeout=1800.0)` rather than exiting (`return`), preserving task reactivity.

### 2. UI Speaker Revival (`Revive Speaker` Button)
- Added dedicated `button.<speaker>_revive` entity to refresh auth tokens and IP addresses, reset status from unsupported/unavailable to idle, and immediately revive paused scan loops from the Home Assistant UI.
- Enhanced existing `button.<speaker>_trigger_scan` to revive halted speakers when clicked.

### 3. Zeroconf Instance & Deprecation Fix
- Directly passed Home Assistant's managed Zeroconf instance to `ServiceBrowser` without instantiating a second `Zeroconf()`. Eliminates duplicate socket listeners and the HA deprecation warning while accelerating IPv4 discovery via HA's warm mDNS cache.

### 4. Device Registry Deprecation Fix
- Avoided calling `.values()` or mapping checks on `device_registry.devices`, directly iterating the collection to maintain compatibility with Home Assistant 2027.9.0.